### PR TITLE
Remove custom styling for API signatures

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -220,20 +220,6 @@ table.docutils tbody td {
     height: 22px;
 }
 
-/* ----- API signatures ----- */
-dl.py.class > dt,
-dl.py.function > dt,
-dl.py.method > dt,
-dl.py.attribute > dt,
-dl.py.data > dt {
-    background: var(--color-background-secondary);
-    border-left: 3px solid var(--color-brand-primary);
-    border-radius: var(--pyd-radius-sm);
-    padding: 0.65rem 0.9rem;
-    font-family: var(--font-stack--monospace);
-    font-size: 0.875rem;
-}
-
 /* ----- Footer ----- */
 .footer-icons {
     display: flex;


### PR DESCRIPTION
## Summary
Removed custom CSS styling rules that were applied to API signature elements in the documentation.

## Changes
- Deleted the "API signatures" CSS rule block that styled Python class, function, method, attribute, and data definition terms (`dl.py.*` selectors)
- This removes the custom background color, left border, border radius, padding, and font styling that was previously applied to these elements

## Details
The removed styles included:
- Secondary background color
- Primary brand-colored left border (3px)
- Small border radius
- Custom padding
- Monospace font family and reduced font size (0.875rem)

These elements will now use default or theme-provided styling instead of the custom overrides.

https://claude.ai/code/session_01L5gxX5aFm2efyiX8eMTyLY