### PR TITLE
Fix mid-capture promotion handling in Russian draughts

### DIFF
--- a/draughts/boards/base.py
+++ b/draughts/boards/base.py
@@ -440,21 +440,23 @@ class BaseBoard(ABC):
         if prefix:
             fen = fen.replace(prefix.group(0), prefix.group(0)[2:])
 
-        turn_m, white_m, black_m = (
-            re.search(r"[WB]:", fen),
-            re.search(r"W[0-9K,]+", fen),
-            re.search(r"B[0-9K,]+", fen),
-        )
+        turn_m = re.search(r"[WB]:", fen)
+        # Piece lists are always preceded by the field-separating colon, so we
+        # anchor on ``:W``/``:B`` to avoid matching the leading turn token. The
+        # ``*`` quantifier allows an empty list (e.g. a side with no pieces left,
+        # which ``fen`` can legitimately emit for a finished game).
+        white_m = re.search(r":W([0-9K,]*)", fen)
+        black_m = re.search(r":B([0-9K,]*)", fen)
         if not turn_m or not white_m or not black_m:
             raise ValueError(f"Invalid FEN: {fen}")
 
         position = np.zeros(cls.SQUARES_COUNT, dtype=np.int8)
-        for sq_str in white_m.group(0)[1:].split(","):
+        for sq_str in white_m.group(1).split(","):
             if sq_str.isdigit():
                 position[int(sq_str) - 1] = -1
             elif sq_str.startswith("K"):
                 position[int(sq_str[1:]) - 1] = -2
-        for sq_str in black_m.group(0)[1:].split(","):
+        for sq_str in black_m.group(1).split(","):
             if sq_str.isdigit():
                 position[int(sq_str) - 1] = 1
             elif sq_str.startswith("K"):

--- a/draughts/boards/base.py
+++ b/draughts/boards/base.py
@@ -242,17 +242,23 @@ class BaseBoard(ABC):
             self.black_kings = (self.black_kings & ~src_bit) | tgt_bit
 
         if is_finished:
-            # Promotion
-            if piece == -1 and (self.PROMO_WHITE & tgt_bit):
+            # Promotion. ``move.is_promotion`` may already be set by variants with
+            # mid-capture promotion (e.g. Russian), where a man crowns part-way
+            # through a capture and finishes on a square off the promotion rank.
+            promoted = False
+            if piece == -1 and ((self.PROMO_WHITE & tgt_bit) or move.is_promotion):
                 self.white_men &= ~tgt_bit
                 self.white_kings |= tgt_bit
                 move.is_promotion = True
-            elif piece == 1 and (self.PROMO_BLACK & tgt_bit):
+                promoted = True
+            elif piece == 1 and ((self.PROMO_BLACK & tgt_bit) or move.is_promotion):
                 self.black_men &= ~tgt_bit
                 self.black_kings |= tgt_bit
                 move.is_promotion = True
-            # Halfmove clock
-            elif abs(piece) == 2 and not move.captured_list:
+                promoted = True
+            # Halfmove clock: only quiet king moves advance it; promotions,
+            # captures and man moves are irreversible progress and reset it.
+            if not promoted and abs(piece) == 2 and not move.captured_list:
                 self.halfmove_clock += 1
             else:
                 self.halfmove_clock = 0

--- a/draughts/move.py
+++ b/draughts/move.py
@@ -112,7 +112,9 @@ class Move:
             self.square_list + other.square_list[1:],
             new_captured,
             self.captured_entities + other.captured_entities,
-            self.is_promotion,
+            # A combined capture promotes if *any* segment crowns the piece
+            # (e.g. Russian mid-capture promotion on a non-first jump).
+            self.is_promotion or other.is_promotion,
         )
         move._len = len(new_captured) + 1
         return move

--- a/test/test_russian_board.py
+++ b/test/test_russian_board.py
@@ -225,6 +225,27 @@ class TestRussianMidCapturePromotion:
         assert board.white_men & (1 << 10)
         assert board.white_kings == 0
 
+    def test_mid_promotion_on_later_jump_is_king_after_push(self):
+        """
+        Promotion can occur on a *non-first* jump of a capture chain. The
+        combined move must still be flagged as a promotion (Move.__add__ ORs
+        the flag) and push must crown the piece.
+        """
+        # White man idx17 jumps idx13 -> idx8, jumps idx5 -> idx1 (promo row 0,
+        # crowns), then as king jumps idx6 -> idx10 (off the promo rank).
+        position = np.zeros(32, dtype=np.int8)
+        position[17] = -1
+        position[13] = 1
+        position[5] = 1
+        position[6] = 1
+        board = Board(position, Color.WHITE)
+
+        move = next(m for m in board.legal_moves if m.square_list == [17, 8, 1, 10])
+        assert move.is_promotion, "Promotion on a later jump must set is_promotion"
+        board.push(move)
+        assert board.white_kings & (1 << 10), "Piece must be a king after push"
+        assert not (board.white_men & (1 << 10))
+
     def test_mid_promotion_continues_as_king(self):
         """After mid-capture promotion, piece moves as flying king."""
         # This is a complex scenario requiring specific setup

--- a/test/test_russian_board.py
+++ b/test/test_russian_board.py
@@ -199,6 +199,32 @@ class TestRussianMidCapturePromotion:
         promoted_captures = [m for m in captures if m.is_promotion]
         assert len(promoted_captures) > 0, "Should have promotion captures"
 
+    def test_mid_promotion_piece_is_king_after_push(self):
+        """
+        After a man promotes mid-capture and continues, ``push`` must leave a
+        KING (not a man) on the final landing square, even though that square
+        is off the promotion rank.
+        """
+        # White man at F6 (sq 10) jumps E7 (sq 6) -> D8 (sq 1, promotes), then
+        # as a king jumps C7 (sq 5) -> B6 (sq 8), which is NOT on the promo rank.
+        position = np.zeros(32, dtype=np.int8)
+        position[10] = -1  # White man F6
+        position[6] = 1  # Black man E7
+        position[5] = 1  # Black man C7
+        board = Board(position, Color.WHITE)
+
+        move = next(m for m in board.legal_moves if m.square_list[-1] == 8)
+        assert move.is_promotion
+        board.push(move)
+
+        assert board.white_kings & (1 << 8), "Promoted piece must be a king"
+        assert not (board.white_men & (1 << 8)), "Promoted piece must not stay a man"
+
+        # And undo must restore the original man.
+        board.pop()
+        assert board.white_men & (1 << 10)
+        assert board.white_kings == 0
+
     def test_mid_promotion_continues_as_king(self):
         """After mid-capture promotion, piece moves as flying king."""
         # This is a complex scenario requiring specific setup

--- a/test/test_standard_board.py
+++ b/test/test_standard_board.py
@@ -33,6 +33,17 @@ class TestBoard:
             assert np.array_equal(board1.position, board2.position)
             assert board1.turn == board2.turn
 
+    def test_fen_roundtrip_with_empty_side(self):
+        """A board where one side has no pieces must round-trip through its own FEN."""
+        for pos in (
+            # Empty black side (white about to win) - fen emits an empty "B" list.
+            np.array([-1 if i in (30, 31) else 0 for i in range(50)], dtype=np.int8),
+            # Empty white side - fen emits an empty "W" list.
+            np.array([1 if i in (0, 1) else 0 for i in range(50)], dtype=np.int8),
+        ):
+            board = Board(pos)
+            assert np.array_equal(Board.from_fen(board.fen).position, board.position)
+
     def test_legal_moves(self):
         with open(self.legal_mvs_file) as f:
             legal_moves_len = json.load(f)


### PR DESCRIPTION
## Summary
This PR fixes promotion handling for Russian draughts, where a man can promote mid-capture and continue jumping as a king on squares off the promotion rank. The changes ensure that pieces are correctly crowned and that FEN parsing handles edge cases with empty piece lists.

## Key Changes

- **Mid-capture promotion in Russian draughts**: Modified `Board.push()` to recognize `move.is_promotion` flag set by variants with mid-capture promotion, allowing pieces to be crowned even when landing off the promotion rank after continuing a capture chain.

- **Move combination logic**: Updated `Move.__add__()` to OR promotion flags when combining capture segments, ensuring that promotion on any segment of a multi-jump sequence is preserved in the final move.

- **FEN parsing robustness**: Fixed regex patterns in `BaseBoard.from_fen()` to:
  - Anchor piece list patterns to the field-separating colon (`:W` and `:B`) to avoid matching the turn token
  - Use capture groups to extract piece lists, allowing empty lists for sides with no pieces
  - Handle legitimate FEN strings for finished games where one side has been eliminated

- **Halfmove clock logic**: Clarified that promotions reset the halfmove clock (they represent irreversible progress), not just captures and man moves.

## Testing
Added comprehensive test cases covering:
- Mid-promotion piece state after `push()` and `pop()`
- Promotion on non-first jumps in capture chains
- FEN round-tripping with empty piece lists

https://claude.ai/code/session_01LKUiL8Hax7gTAJty34TFPV