### PR TITLE
Fix FEN side-to-move token and one-sided position parsing (#26, #28)

### DIFF
--- a/docs/source/core.rst
+++ b/docs/source/core.rst
@@ -97,7 +97,7 @@ FEN represents board positions. Format: ``[Turn]:[White pieces]:[Black pieces]``
 
     # Get FEN
     print(board.fen)
-    # '[FEN "W:W:W31,32,...,50:B1,2,...,20"]'
+    # '[FEN "W:W31,32,...,50:B1,2,...,20"]'
 
     # Create from FEN (kings prefixed with K)
     board = Board.from_fen("W:WK10,K20:BK35,K45")

--- a/draughts/boards/base.py
+++ b/draughts/boards/base.py
@@ -414,7 +414,7 @@ class BaseBoard(ABC):
                 black_sq.append(str(sq + 1))
             elif self.black_kings & bit:
                 black_sq.append(f"K{sq + 1}")
-        return f'[FEN "W:{turn_s}:W{",".join(white_sq)}:B{",".join(black_sq)}"]'
+        return f'[FEN "{turn_s}:W{",".join(white_sq)}:B{",".join(black_sq)}"]'
 
     @classmethod
     def from_fen(cls, fen: str) -> BaseBoard:
@@ -436,9 +436,23 @@ class BaseBoard(ABC):
         logger.debug(f"Initializing from FEN: {fen}")
         fen = fen.upper()
         fen = re.sub(r"(G[0-9]+|P[0-9]+)(,|)", "", fen)
-        prefix = re.search(r"[WB]:[WB]:[WB]", fen)
-        if prefix:
-            fen = fen.replace(prefix.group(0), prefix.group(0)[2:])
+        # Unwrap the optional ``[FEN "..."]`` container so the colon-separated
+        # fields can be counted reliably below.
+        wrap = re.search(r'\[FEN\s*"([^"]*)"\]', fen)
+        if wrap:
+            fen = wrap.group(1)
+        # Older versions emitted a redundant leading side-to-move token, e.g.
+        # ``W:B:W...:B...`` instead of the canonical ``B:W...:B...``. A canonical
+        # FEN has exactly three colon-separated fields (turn, white list, black
+        # list); the legacy form has four, with a bare extra turn letter in
+        # front. Drop that leading token so both forms parse identically.
+        # Counting fields (rather than a ``[WB]:[WB]:[WB]`` regex) avoids
+        # misreading a one-sided position such as ``B:W:B1`` (empty white side)
+        # as if it carried a legacy prefix.
+        fields = fen.split(":")
+        if len(fields) == 4 and fields[0] in ("W", "B"):
+            del fields[0]
+            fen = ":".join(fields)
 
         turn_m = re.search(r"[WB]:", fen)
         # Piece lists are always preceded by the field-separating colon, so we

--- a/readme.md
+++ b/readme.md
@@ -115,7 +115,7 @@ False
 
 ```python
 >>> board.fen
-'[FEN "W:W:W31,32,33,...:B1,2,3,..."]'
+'[FEN "W:W31,32,33,...:B1,2,3,..."]'
 
 >>> board = draughts.Board.from_fen("W:WK10,K20:BK35,K45")
 >>> board

--- a/test/test_standard_board.py
+++ b/test/test_standard_board.py
@@ -44,6 +44,35 @@ class TestBoard:
             board = Board(pos)
             assert np.array_equal(Board.from_fen(board.fen).position, board.position)
 
+    def test_fen_has_single_side_to_move_token(self):
+        """``board.fen`` must carry the side to move exactly once (issue #26).
+
+        The canonical FEN layout is ``<turn>:W<white>:B<black>``; older output
+        duplicated the token (``W:W:...`` / ``W:B:...``).
+        """
+        white_to_move = Board()
+        assert white_to_move.fen.startswith('[FEN "W:W')
+        assert ":W:" not in white_to_move.fen
+
+        black_to_move = Board.from_fen("B:W31:B1")
+        assert black_to_move.fen.startswith('[FEN "B:W')
+        assert ":B:" not in black_to_move.fen
+
+    def test_from_fen_accepts_one_sided_position(self):
+        """A FEN with one empty side must be accepted (issue #28)."""
+        board = Board.from_fen("B:W50:B")
+        assert board.turn == Color.BLACK
+        assert board._get(49) == -1  # white man on square 50
+        assert board.white_men.bit_count() == 1
+        assert board.black_men == board.black_kings == 0
+
+    def test_from_fen_accepts_legacy_doubled_prefix(self):
+        """Legacy FENs with a duplicated side-to-move token still parse."""
+        legacy = Board.from_fen('[FEN "W:B:W50:B"]')
+        canonical = Board.from_fen('[FEN "B:W50:B"]')
+        assert legacy.turn == canonical.turn == Color.BLACK
+        assert np.array_equal(legacy.position, canonical.position)
+
     def test_legal_moves(self):
         with open(self.legal_mvs_file) as f:
             legal_moves_len = json.load(f)


### PR DESCRIPTION
## Summary

Fixes two closely-related FEN correctness bugs. They share the same area (`board.fen` output and `from_fen` parsing) and issue #28's own example exhibits the #26 bug, so they're addressed together.

### #26 — `board.fen` had a doubled side-to-move token
`board.fen` produced `[FEN "W:W:W31,…:B1,…"]` (and `W:B:…` for black to move). The standard draughts FEN only carries the side to move **once** at the front. The property now emits the canonical `[FEN "<turn>:W<white>:B<black>"]`.

```
before:  [FEN "W:W:W31,…:B1,…"]
after:   [FEN "W:W31,…:B1,…"]
```

### #28 — valid one-sided FEN rejected / mis-parsed
`Board.from_fen('B:W50:B')` (a white piece on 50, no black pieces) is valid but failed. `from_fen` now normalizes the optional legacy duplicated token by **counting colon-separated fields** (canonical = 3 fields, legacy = 4) instead of the old `[WB]:[WB]:[WB]` regex, which mis-fired on one-sided positions. The `[FEN "…"]` wrapper is unwrapped first so field counting is reliable.

## Backward compatibility
Legacy FENs that still carry the duplicated token (`[FEN "W:B:W50:B"]`, plain `W:W:…`, `B:B:…`) continue to parse identically — verified by a new regression test.

## Tests
Added to `test/test_standard_board.py`:
- `test_fen_has_single_side_to_move_token` (#26)
- `test_from_fen_accepts_one_sided_position` (#28)
- `test_from_fen_accepts_legacy_doubled_prefix` (backward compat)

Full suite: **359 passed** (was 356). Docs/readme FEN examples updated to the canonical form.

Closes #26
Closes #28

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPd9CXSnz9Cn9eenS7iDTQ)_