### PR TITLE
Reject push() of a move with no side-to-move piece at its source (#27)

### DIFF
--- a/draughts/boards/base.py
+++ b/draughts/boards/base.py
@@ -221,14 +221,30 @@ class BaseBoard(ABC):
             is_finished: If True, switches turn after the move. Set to False
                 during internal move generation.
 
+        Raises:
+            ValueError: If the move does not start from a square occupied by a
+                piece of the side to move (e.g. an empty square or an opponent
+                piece). This guards against applying a stale or foreign
+                :class:`Move` that would silently corrupt the position.
+
         Example:
             >>> board = Board()
             >>> move = board.legal_moves[0]
             >>> board.push(move)
         """
-        move.halfmove_clock = self.halfmove_clock
         src, tgt = move.square_list[0], move.square_list[-1]
         piece = self._get(src)
+        # Reject moves whose source holds no piece of the side to move. White
+        # pieces are negative, black positive; an empty square is 0. Without
+        # this, pushing such a move falls through to the black-king branch and
+        # corrupts the board (see issue #27).
+        if piece == 0 or (piece < 0) != (self.turn == Color.WHITE):
+            raise ValueError(
+                f"Illegal move {move}: square {src + 1} holds no "
+                f"{'white' if self.turn == Color.WHITE else 'black'} piece to move."
+            )
+
+        move.halfmove_clock = self.halfmove_clock
         src_bit, tgt_bit = 1 << src, 1 << tgt
 
         # Move piece

--- a/test/test_standard_board.py
+++ b/test/test_standard_board.py
@@ -111,3 +111,22 @@ class TestBoard:
         assert test_board.position[40] == -1, "White piece on square 41 was incorrectly captured"
         # Square 6 (0-indexed: 5) should still have a white piece
         assert test_board.position[5] == -1, "White piece on square 6 was incorrectly captured"
+
+    def test_push_rejects_move_with_empty_source(self):
+        """Re-pushing a spent move must not corrupt the board (issue #27)."""
+        board = Board.from_fen("W:WK2,25:B14,15,16")
+        move = board.legal_moves[0]
+        board.push(move)  # 25-20, now Black to move; square 25 is empty
+        before = board.position.copy()
+        with pytest.raises(ValueError):
+            board.push(move)
+        # Position must be untouched by the rejected push.
+        assert np.array_equal(board.position, before)
+
+    def test_push_rejects_opponent_piece(self):
+        """Pushing a move for a square holding an opponent piece is rejected."""
+        board = Board.from_fen("W:W31:B20")  # White to move
+        # Fabricate a move that starts on the black piece at square 20.
+        black_move = Move([19, 14])
+        with pytest.raises(ValueError):
+            board.push(black_move)


### PR DESCRIPTION
## Summary

`Board.push()` trusted whatever `Move` it was given and never checked that the move actually starts from a piece of the side to move. Re-pushing an already-played move (its source now empty) or pushing a move for an opponent piece made `_get(src)` return `0`, which fell through to the `else` (black-king) branch and **silently corrupted the board** — spawning a phantom king.

Reproduction from the issue:

```python
position = 'W:WK2,25:B14,15,16'
board = Board.from_fen(position)
m = board.legal_moves[0]
board.push(m)
board.push(m)   # same move again
```

Before: second push produced `[FEN "W:W:WK2,20:B14,15,16,K20"]` (a bogus black `K20` appears).
After: the second push raises `ValueError: Illegal move 25-20: square 25 holds no black piece to move.` and the board is left untouched.

## Implementation

`push()` now validates that the source square holds a piece of the side to move (white pieces are negative, black positive, empty is `0`) and raises `ValueError` otherwise. It's a sign check on a value `push()` already computes, so internal move generation and engine search (which only ever push legal moves) are unaffected — full suite still **356 passed**.

## Tests
Added to `test/test_standard_board.py`:
- `test_push_rejects_move_with_empty_source` (the issue's double-push case; asserts the position is unchanged after the rejected push)
- `test_push_rejects_opponent_piece`

Closes #27

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPd9CXSnz9Cn9eenS7iDTQ)_