### PR TITLE
Disambiguate capture moves by spelling out the full path (#29)

### DIFF
--- a/draughts/move.py
+++ b/draughts/move.py
@@ -65,9 +65,16 @@ class Move:
         self._is_king_move = False
 
     def __str__(self) -> str:
-        """Return UCI notation, e.g. '31-27' or '26x17'."""
-        separator = "x" if self.captured_list else "-"
-        return f"{self.square_list[0] + 1}{separator}{self.square_list[-1] + 1}"
+        """Return UCI notation, e.g. ``'31-27'`` or ``'4x27x38x15'``.
+
+        Captures spell out every visited square, not just the start and end.
+        Two capture sequences can share the same start and end square while
+        taking different routes (e.g. ``4x27x38x15`` vs ``4x31x42x15``); always
+        including the full path keeps such moves distinguishable (issue #29).
+        """
+        if not self.captured_list:
+            return f"{self.square_list[0] + 1}-{self.square_list[-1] + 1}"
+        return "x".join(str(sq + 1) for sq in self.square_list)
 
     def __repr__(self) -> str:
         visited_squares = [str(s + 1) for s in self.square_list]
@@ -155,10 +162,23 @@ class Move:
             raise ValueError(f"Invalid move format: {move}")
 
         move_obj = Move([int(step) - 1 for step in steps])
-        for legal_move in legal_moves:
-            if legal_move == move_obj:
-                return legal_move
+        legal_moves = list(legal_moves)
+        matches = [legal_move for legal_move in legal_moves if legal_move == move_obj]
+        if len(matches) == 1:
+            return matches[0]
+        if not matches:
+            raise ValueError(
+                f"{str(move_obj)} is correct format, but not legal in this position.\n"
+                f"Legal moves: {list(map(str, legal_moves))}"
+            )
+        # Several legal moves share this start/end square. This happens when a
+        # capture is given by its endpoints only but multiple routes exist
+        # (issue #29). Require the exact intermediate path to disambiguate.
+        exact = [m for m in matches if m.square_list == move_obj.square_list]
+        if len(exact) == 1:
+            return exact[0]
         raise ValueError(
-            f"{str(move_obj)} is correct format, but not legal in this position.\n"
-            f"Legal moves: {list(map(str, legal_moves))}"
+            f"{move} is ambiguous: it matches multiple capture paths "
+            f"{list(map(str, matches))}. Specify the full path including the "
+            f"intermediate squares."
         )

--- a/test/test_standard_board.py
+++ b/test/test_standard_board.py
@@ -55,15 +55,16 @@ class TestBoard:
     @pytest.mark.parametrize(
         "fen,valid_moves,invalid_moves",
         [
-            # King multi-capture: can capture three pieces in sequence (44, 28, 31)
-            ('[FEN "W:B:WK2,28,31,44:B20,K50"]', ["50x36"], []),
+            # King multi-capture: can capture three pieces ending on 36.
+            # Capture notation spells out the full path (issue #29).
+            ('[FEN "W:B:WK2,28,31,44:B20,K50"]', ["50x39x22x36"], []),
             # King cannot jump adjacent pieces (28 and 33 have no empty square between)
             ('[FEN "W:B:W7,28,31,33:B20,30,K50"]', [], ["50x50"]),
             # King cannot hop over same piece twice during capture sequence
             # Black king on 49 should capture 38, 28, 24 (path: 49->32->19->30/35)
             # It should NOT capture 41 because to reach it after capturing 38,
             # and then continue to 28, would require crossing 41's square twice
-            ('[FEN "W:B:W6,24,28,38,41:B13,K49"]', ["49x30", "49x35"], []),
+            ('[FEN "W:B:W6,24,28,38,41:B13,K49"]', ["49x32x19x30", "49x32x19x35"], []),
         ],
     )
     def test_king_capture_edge_cases(self, fen, valid_moves, invalid_moves):
@@ -111,3 +112,21 @@ class TestBoard:
         assert test_board.position[40] == -1, "White piece on square 41 was incorrectly captured"
         # Square 6 (0-indexed: 5) should still have a white piece
         assert test_board.position[5] == -1, "White piece on square 6 was incorrectly captured"
+
+    def test_ambiguous_captures_are_disambiguated(self):
+        """Captures sharing start/end must be distinguishable by their path (issue #29)."""
+        board = Board.from_fen("W:WK4:B13,32,37,20")
+        capture_strs = [str(m) for m in board.legal_moves if m.captured_list]
+        # Both routes from 4 to 15 must be present with distinct full paths.
+        assert sorted(capture_strs) == ["4x27x38x15", "4x31x42x15"]
+
+        # The bare endpoint form is ambiguous and must be rejected, not
+        # silently resolved to an arbitrary path.
+        with pytest.raises(ValueError, match="ambiguous"):
+            board.push_uci("4x15")
+
+        # The full path selects exactly the intended capture: 4x31x42x15
+        # removes the pieces on 13, 37 and 20, leaving the one on 32.
+        board.push_uci("4x31x42x15")
+        assert board._get(31) == 1  # piece on square 32 survives (0-indexed 31)
+        assert board._get(12) == board._get(36) == board._get(19) == 0


### PR DESCRIPTION
## Summary

Two capture sequences can share the same start and end square while taking different routes. In the issue's position (`W:WK4`, `B:13,32,37,20`), `4x15` can be either `4x27x38x15` or `4x31x42x15`. Both were rendered as the string `4x15`, and `push_uci('4x15')` silently picked whichever matched first — so a caller could neither distinguish the two legal moves nor reliably select one.

```python
board = Board.from_fen("W:WK4:B13,32,37,20")
[str(m) for m in board.legal_moves if m.captured_list]
# before: ['4x15', '4x15']
# after:  ['4x27x38x15', '4x31x42x15']
```

## Changes

- **`Move.__str__`** now renders captures as their full visited path (`4x27x38x15`) instead of just the endpoints. Single jumps are unchanged (`26x17`).
- **`Move.from_uci`** returns a move directly when the endpoints identify it unambiguously. When several legal captures share those endpoints, it requires the full path; if the bare endpoint form is given it raises a `ValueError` naming the candidate paths rather than guessing:

  ```
  4x15 is ambiguous: it matches multiple capture paths
  ['4x27x38x15', '4x31x42x15']. Specify the full path including the
  intermediate squares.
  ```

## Compatibility notes
- Single-capture notation is unchanged, so existing PDN/UCI for non-branching captures still round-trips.
- The UCI round-trip property test (`str(move)` → `from_uci` → same move) holds, since the full path matches its own move exactly.
- Two existing king-capture edge-case assertions were updated from the old endpoint form to the full path.

## Tests
- New `test_ambiguous_captures_are_disambiguated` covering distinct paths, rejection of the ambiguous short form, and correct piece removal for the chosen path.
- Full suite: **357 passed**.

Closes #29

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPd9CXSnz9Cn9eenS7iDTQ)_