### PR TITLE
fix: remove duplicate windmill capture moves (#34)

### DIFF
--- a/draughts/boards/base.py
+++ b/draughts/boards/base.py
@@ -405,6 +405,41 @@ class BaseBoard(ABC):
         """
         return bool(move.captured_list)
 
+    @staticmethod
+    def _dedupe_captures(captures: list[Move]) -> list[Move]:
+        """
+        Drop capture sequences that are indistinguishable outcomes.
+
+        A "windmill" king capture can reach the same landing square while
+        capturing the same set of pieces via more than one visiting order
+        (e.g. ``2x13x22x11x2`` and ``2x11x22x13x2`` on ``W:WK2:B7,8,17,18``).
+        Those leave a byte-identical position, so only the first is kept
+        (issue #34). Moves that differ in start square, landing square, the
+        set of captured squares, or promotion outcome are all preserved, so
+        genuinely distinct routes (issue #29) are untouched.
+
+        Args:
+            captures: Candidate capture moves, already filtered to the ones
+                that are legal for the variant.
+
+        Returns:
+            The input list with duplicate-outcome moves removed, order kept.
+        """
+        seen: set[tuple] = set()
+        unique: list[Move] = []
+        for move in captures:
+            key = (
+                move.square_list[0],
+                move.square_list[-1],
+                tuple(sorted(move.captured_list)),
+                move.is_promotion,
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            unique.append(move)
+        return unique
+
     @property
     def fen(self) -> str:
         """

--- a/draughts/boards/brazilian.py
+++ b/draughts/boards/brazilian.py
@@ -35,7 +35,7 @@ class Board(RussianBoard):
         captures = self._gen_captures()
         if captures:
             max_len = max(m._len for m in captures)
-            return [m for m in captures if m._len == max_len]
+            return self._dedupe_captures([m for m in captures if m._len == max_len])
         return self._gen_simple()
 
     def _man_captures(

--- a/draughts/boards/standard.py
+++ b/draughts/boards/standard.py
@@ -101,7 +101,7 @@ class Board(BaseBoard):
         captures = self._gen_captures()
         if captures:
             max_len = max(m._len for m in captures)
-            return [m for m in captures if m._len == max_len]
+            return self._dedupe_captures([m for m in captures if m._len == max_len])
         return self._gen_simple()
 
     def _gen_simple(self) -> list[Move]:

--- a/test/test_standard_board.py
+++ b/test/test_standard_board.py
@@ -178,3 +178,20 @@ class TestBoard:
         black_move = Move([19, 14])
         with pytest.raises(ValueError):
             board.push(black_move)
+
+    def test_windmill_capture_has_no_duplicate(self):
+        """A windmill king capture must be offered once, not once per order (issue #34)."""
+        board = Board.from_fen("W:WK2:B7,8,17,18")
+        moves = [m for m in board.legal_moves if m.captured_list]
+        # Every path here starts and ends on 2 and captures the same four pieces,
+        # so exactly one representative move must remain.
+        assert len(moves) == 1
+        move = moves[0]
+        assert move.square_list[0] == move.square_list[-1] == 1  # square 2, 0-indexed
+        assert sorted(c + 1 for c in move.captured_list) == [7, 8, 17, 18]
+
+    def test_dedupe_keeps_distinct_capture_routes(self):
+        """Routes capturing different piece sets must both survive (issue #29 vs #34)."""
+        board = Board.from_fen("W:WK4:B13,32,37,20")
+        capture_strs = sorted(str(m) for m in board.legal_moves if m.captured_list)
+        assert capture_strs == ["4x27x38x15", "4x31x42x15"]


### PR DESCRIPTION
Fixes #34.

## Problem
`Board.from_fen('W:WK2:B7,8,17,18').legal_moves` returned two moves — `2x13x22x11x2` and `2x11x22x13x2`. They differ only in the order the pieces are captured; both end with the white king back on square 2 and the same four pieces removed, i.e. an identical resulting position.

## Changes
- Add `BaseBoard._dedupe_captures`, which collapses capture moves that share the same start square, landing square, set of captured squares, and promotion outcome — keeping the first and preserving order.
- Apply it in the `standard` and `brazilian` max-capture filters (both use the identical international max-length rule and share the king windmill mechanic).

Because the dedup key includes the full set of captured squares, genuinely distinct routes that capture *different* pieces (issue #29, e.g. `4x27x38x15` vs `4x31x42x15`) keep separate keys and are untouched.

## Tests
- `test_windmill_capture_has_no_duplicate`: the windmill position now yields exactly one capture.
- `test_dedupe_keeps_distinct_capture_routes`: the issue #29 two-route position still returns both moves.

Full suite: 364 passed.