### PR TITLE
chore: release 1.8.4

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.8.4
+
+Bug fixes:
+
+- **FEN validation** (#33): `Board.from_fen` now rejects illegal FENs (stray characters in a piece list, squares outside `1..SQUARES_COUNT`, and duplicate squares) instead of silently building a corrupt board.
+- **FEN square ranges** (#33): piece lists accept dash ranges, e.g. the international start position `W:W31-50:B1-20` (and `K`-prefixed ranges like `WK4-6`).
+- **Windmill duplicate captures** (#34): a king capture that reaches the same square capturing the same pieces via different orders is now offered once instead of once per order (standard and Brazilian). Distinct routes capturing different pieces are unaffected.
+
 ## 1.8.3
 
 Bug fixes:

--- a/draughts/__init__.py
+++ b/draughts/__init__.py
@@ -25,7 +25,7 @@ import sys
 
 from loguru import logger
 
-__version__ = "1.8.3"
+__version__ = "1.8.4"
 
 # Remove default stderr handler (id=0) - users can add their own with logger.add(sys.stderr)
 try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "py-draughts"
-version = "1.8.3"
+version = "1.8.4"
 description = "Fastest Python draughts / checkers library (import: draughts). Bitboard move generation ~200x faster than pydraughts. PDN/FEN, alpha-beta engine, HUB protocol, web UI. 8 variants: International, American, Frisian, Russian, Brazilian, Antidraughts, Breakthrough, Frysk!"
 readme = "readme.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
Version bump to 1.8.4 for release.

Includes the two bug fixes already merged since 1.8.3:
- FEN validation + square ranges (#33, PR #35)
- Windmill duplicate capture dedup (#34, PR #36)

Bumps `pyproject.toml`, `draughts/__init__.py`, and adds a changelog entry. Merging this and tagging `v1.8.4` triggers the PyPI publish workflow.