### PR TITLE
TurboEngine as flagship: replace AlphaBetaEngine with SimpleEngine, add benchmarking tooling + v4 investigation

### DIFF
--- a/docs/source/benchmarking.rst
+++ b/docs/source/benchmarking.rst
@@ -48,7 +48,7 @@ Performance of the legal moves generator across different board positions:
 Engine Depth Performance
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-AlphaBeta engine search performance at different depths:
+SimpleEngine search performance at different depths:
 
 .. image:: _static/engine_benchmark.png
    :alt: Engine Depth Benchmark

--- a/docs/source/comparison.rst
+++ b/docs/source/comparison.rst
@@ -9,7 +9,7 @@ This page compares **py-draughts** (this library, import name ``draughts``) with
 `pydraughts <https://pypi.org/project/pydraughts/>`_, the other commonly used
 Python draughts library. If you are picking between them, the short version:
 py-draughts is dramatically faster, ships with more variants, includes a
-built-in alpha-beta engine, a web UI, SVG rendering, and ML/RL helpers.
+built-in engines, a web UI, SVG rendering, and ML/RL helpers.
 
 .. note::
 
@@ -32,7 +32,7 @@ At a glance
      - Bitboards (NumPy ``uint64``)
      - Object lists
    * - Built-in AI engine
-     - ✅ Alpha-beta + transposition tables + iterative deepening
+     - ✅ TurboEngine (ML eval, 10x10) + SimpleEngine (alpha-beta, all variants)
      - ❌ External engines only
    * - Engine benchmarking suite
      - ✅ ``Benchmark`` class with Elo, win-rate, statistics
@@ -160,13 +160,13 @@ read py-draughts code immediately.
 
 .. code-block:: python
 
-   from draughts import Board, AlphaBetaEngine
+   from draughts import Board, SimpleEngine
 
    board = Board()
    board.push_uci("31-27")
    board.push_uci("18-22")
 
-   engine = AlphaBetaEngine(depth_limit=6)
+   engine = SimpleEngine(depth_limit=6)
    best, score = engine.get_best_move(board, with_evaluation=True)
 
 When to pick which
@@ -221,6 +221,6 @@ See also
 --------
 
 - :doc:`core` — Board API reference
-- :doc:`engine` — built-in alpha-beta engine and HUB protocol bridge
+- :doc:`engine` — built-in engines and HUB protocol bridge
 - :doc:`benchmarking` — how the performance numbers above were produced
 - :doc:`ai` — tensor exports, legal-move masks, RL example

--- a/docs/source/engine.rst
+++ b/docs/source/engine.rst
@@ -1,21 +1,23 @@
 .. meta::
-   :description: py-draughts engine — built-in alpha-beta search with transposition tables and iterative deepening, plus a HUB protocol bridge for external engines like Scan and Kingsrow.
-   :keywords: draughts engine, alpha-beta draughts, hub protocol, scan engine, kingsrow, python checkers ai, transposition table
+   :description: py-draughts engines — TurboEngine, a machine-learned pattern evaluation with PVS search for international draughts, and SimpleEngine, a general-purpose alpha-beta engine for every variant, plus a HUB protocol bridge for external engines like Scan and Kingsrow.
+   :keywords: draughts engine, turboengine, machine-learned evaluation, alpha-beta draughts, hub protocol, scan engine, kingsrow, python checkers ai, transposition table
 
 Engine
 ======
 
-AI engines for playing draughts.
+Two engines are built in: :class:`~draughts.TurboEngine` — the strongest, for
+international 10x10 — and :class:`~draughts.SimpleEngine`, a lightweight
+general-purpose engine that works on every variant.
 
 Quick Start
 -----------
 
 .. code-block:: python
 
-    from draughts import Board, AlphaBetaEngine
+    from draughts import Board, TurboEngine
 
     board = Board()
-    engine = AlphaBetaEngine(depth_limit=5)
+    engine = TurboEngine(time_limit=0.5)   # strongest; international 10x10 only
 
     # Get best move
     best_move = engine.get_best_move(board)
@@ -30,14 +32,49 @@ Engine Interface
 .. autoclass:: draughts.Engine
     :members:
 
-AlphaBetaEngine
----------------
+TurboEngine
+-----------
 
-.. autoclass:: draughts.AlphaBetaEngine
+The strongest built-in engine, for the standard international (10x10) board
+only. It uses Scan's 63-bit bitboard layout, a PVS search with transposition
+table, and a machine-learned pattern evaluation trained on Scan self-play.
+At equal time per move it beats :class:`~draughts.SimpleEngine` by several
+hundred Elo while using less time.
+
+.. code-block:: python
+
+    from draughts import Board, TurboEngine
+
+    board = Board()
+    engine = TurboEngine(time_limit=0.5)   # or depth_limit=...
+    move, score = engine.get_best_move(board, with_evaluation=True)
+
+.. autoclass:: draughts.TurboEngine
+    :members: __init__, get_best_move
+
+SimpleEngine
+------------
+
+A lightweight general-purpose engine — alpha-beta search with a transposition
+table and iterative deepening — that works on **every** board variant, unlike
+:class:`~draughts.TurboEngine` (international only). Use it for American,
+Frisian, Russian, Brazilian, and the other variants.
+
+.. code-block:: python
+
+    from draughts import Board, SimpleEngine
+
+    board = Board()
+    engine = SimpleEngine(depth_limit=5)
+    move, score = engine.get_best_move(board, with_evaluation=True)
+
+.. autoclass:: draughts.SimpleEngine
     :members: __init__, evaluate, get_best_move
 
 Performance
 ~~~~~~~~~~~
+
+``SimpleEngine`` search cost by depth:
 
 ============  ============  ============
 Depth         Avg Time      Avg Nodes
@@ -54,26 +91,6 @@ Depth         Avg Time      Avg Nodes
 .. image:: _static/engine_benchmark.png
    :alt: Engine Benchmark
    :width: 500px
-
-TurboEngine
------------
-
-The strongest built-in engine, for the standard international (10x10) board
-only. It uses Scan's 63-bit bitboard layout, a PVS search with transposition
-table, and a machine-learned pattern evaluation trained on Scan self-play.
-At equal time per move it beats :class:`~draughts.AlphaBetaEngine` by several
-hundred Elo while using less time.
-
-.. code-block:: python
-
-    from draughts import Board, TurboEngine
-
-    board = Board()
-    engine = TurboEngine(time_limit=0.5)   # or depth_limit=...
-    move, score = engine.get_best_move(board, with_evaluation=True)
-
-.. autoclass:: draughts.TurboEngine
-    :members: __init__, get_best_move
 
 HubEngine
 ---------
@@ -116,12 +133,12 @@ Quick Start
 
 .. code-block:: python
 
-    from draughts import Benchmark, AlphaBetaEngine
+    from draughts import Benchmark, SimpleEngine
 
     # Compare two engines
     stats = Benchmark(
-        AlphaBetaEngine(depth_limit=4),
-        AlphaBetaEngine(depth_limit=6),
+        SimpleEngine(depth_limit=4),
+        SimpleEngine(depth_limit=6),
         games=20
     ).run()
 
@@ -130,17 +147,17 @@ Quick Start
 Output::
 
     ============================================================
-      BENCHMARK: AlphaBetaEngine (d=4) vs AlphaBetaEngine (d=6)
+      BENCHMARK: SimpleEngine (d=4) vs SimpleEngine (d=6)
     ============================================================
 
       RESULTS: 2-12-6 (W-L-D)
-      AlphaBetaEngine (d=4) win rate: 25.0%
+      SimpleEngine (d=4) win rate: 25.0%
       Elo difference: -191
 
       PERFORMANCE
       Avg game length: 85.3 moves
-      AlphaBetaEngine (d=4): 25.2ms/move, 312 nodes/move
-      AlphaBetaEngine (d=6): 142.5ms/move, 1850 nodes/move
+      SimpleEngine (d=4): 25.2ms/move, 312 nodes/move
+      SimpleEngine (d=6): 142.5ms/move, 1850 nodes/move
       Total time: 45.2s
       ...
 
@@ -166,17 +183,17 @@ Custom Names
 
 Engines with the same class name are automatically distinguished by their settings::
 
-    # These will show as "AlphaBetaEngine (d=4)" and "AlphaBetaEngine (d=6)"
+    # These will show as "SimpleEngine (d=4)" and "SimpleEngine (d=6)"
     Benchmark(
-        AlphaBetaEngine(depth_limit=4),
-        AlphaBetaEngine(depth_limit=6)
+        SimpleEngine(depth_limit=4),
+        SimpleEngine(depth_limit=6)
     )
 
 Or provide custom names::
 
     Benchmark(
-        AlphaBetaEngine(depth_limit=4, name="FastBot"),
-        AlphaBetaEngine(depth_limit=6, name="StrongBot")
+        SimpleEngine(depth_limit=4, name="FastBot"),
+        SimpleEngine(depth_limit=6, name="StrongBot")
     )
 
 Custom Openings
@@ -184,7 +201,7 @@ Custom Openings
 
 By default, 10x10 boards use built-in opening positions. Provide your own::
 
-    from draughts import Benchmark, AlphaBetaEngine, STANDARD_OPENINGS
+    from draughts import Benchmark, SimpleEngine, STANDARD_OPENINGS
 
     # Use specific FEN positions
     custom_openings = [
@@ -193,8 +210,8 @@ By default, 10x10 boards use built-in opening positions. Provide your own::
     ]
 
     stats = Benchmark(
-        AlphaBetaEngine(depth_limit=4),
-        AlphaBetaEngine(depth_limit=6),
+        SimpleEngine(depth_limit=4),
+        SimpleEngine(depth_limit=6),
         openings=custom_openings
     ).run()
 
@@ -206,13 +223,13 @@ Different Board Variants
 
 Test engines on any supported variant::
 
-    from draughts import Benchmark, AlphaBetaEngine
+    from draughts import Benchmark, SimpleEngine
     from draughts import AmericanBoard, FrisianBoard, RussianBoard
 
     # American checkers (8x8)
     stats = Benchmark(
-        AlphaBetaEngine(depth_limit=5),
-        AlphaBetaEngine(depth_limit=7),
+        SimpleEngine(depth_limit=5),
+        SimpleEngine(depth_limit=7),
         board_class=AmericanBoard,
         games=10
     ).run()

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,7 @@
 :layout: landing
 
 .. meta::
-   :description: py-draughts — the fastest Python draughts / checkers library. Bitboard move generation ~200x faster than pydraughts. Built-in alpha-beta engine, HUB protocol, web UI, SVG rendering, ML tensors. 8 variants: International, American, Frisian, Russian, Brazilian, Antidraughts, Breakthrough, Frysk!.
+   :description: py-draughts — the fastest Python draughts / checkers library. Bitboard move generation ~200x faster than pydraughts. Built-in engines (ML-trained TurboEngine + general-purpose SimpleEngine), HUB protocol, web UI, SVG rendering, ML tensors. 8 variants: International, American, Frisian, Russian, Brazilian, Antidraughts, Breakthrough, Frysk!.
    :keywords: python draughts, python checkers, draughts library, checkers library, pydraughts alternative, international draughts, frisian draughts, russian draughts, brazilian draughts, antidraughts, breakthrough, frysk, bitboard, pdn, fen, alpha-beta engine, hub protocol, board game ai
 
 py-draughts
@@ -14,7 +14,7 @@ py-draughts
      <p class="hero-subtitle">
        The fastest pure-Python <strong>draughts / checkers</strong> library —
        bitboard move generation ~200× faster than pydraughts. Built-in
-       alpha-beta engine, HUB protocol bridge (Scan, Kingsrow), web UI,
+       engines (TurboEngine + SimpleEngine), HUB protocol bridge (Scan, Kingsrow), web UI,
        SVG rendering, and ML/RL helpers across 8 variants:
        International, American, Frisian, Russian, Brazilian, Antidraughts,
        Breakthrough, and Frysk!.
@@ -41,8 +41,8 @@ py-draughts
       :link: engine
       :link-type: doc
 
-      Built-in alpha-beta engine, Hub protocol bridge, and a clean
-      ``Engine`` interface for plugging in your own.
+      Built-in engines (TurboEngine + SimpleEngine), Hub protocol bridge,
+      and a clean ``Engine`` interface for plugging in your own.
 
    .. grid-item-card:: :octicon:`zap;1em;sd-text-primary` AI / RL
       :link: ai
@@ -107,13 +107,13 @@ Hello, draughts
 
 .. code-block:: python
 
-   from draughts import Board, AlphaBetaEngine
+   from draughts import Board, SimpleEngine
 
    board = Board()                       # 10x10 international draughts
    board.push_uci("31-27")
    board.push_uci("18-22")
 
-   engine = AlphaBetaEngine(depth_limit=5)
+   engine = SimpleEngine(depth_limit=5)
    board.push(engine.get_best_move(board))
 
    print(board)

--- a/docs/source/server.rst
+++ b/docs/source/server.rst
@@ -15,13 +15,13 @@ Quick Start
 
 .. code-block:: python
 
-    from draughts import Board, Server, AlphaBetaEngine
+    from draughts import Board, Server, SimpleEngine
 
     board = Board()
     server = Server(
         board=board,
-        white_engine=AlphaBetaEngine(depth_limit=6),
-        black_engine=AlphaBetaEngine(depth_limit=4)
+        white_engine=SimpleEngine(depth_limit=6),
+        black_engine=SimpleEngine(depth_limit=4)
     )
     server.run()  # Open http://localhost:8000
 
@@ -37,7 +37,7 @@ Engine Matches
 
 Pit engines against each other::
 
-    from draughts import Board, Server, AlphaBetaEngine, Engine
+    from draughts import Board, Server, SimpleEngine, Engine
     import random
 
     class RandomEngine(Engine):
@@ -47,7 +47,7 @@ Pit engines against each other::
 
     server = Server(
         board=Board(),
-        white_engine=AlphaBetaEngine(depth_limit=6),
+        white_engine=SimpleEngine(depth_limit=6),
         black_engine=RandomEngine()
     )
     server.run()

--- a/docs/turbo-v4-investigation.md
+++ b/docs/turbo-v4-investigation.md
@@ -1,0 +1,169 @@
+# TurboEngine v4 eval-tuning investigation (negative result)
+
+**Date:** 2026-07-13
+**Outcome:** No shippable improvement. A retrained/extended evaluation could not
+beat the shipped v3 `TurboEngine` at any tested time control. v3 remains the
+engine. This document records what was tried, the measurements, the root-cause
+diagnosis, and the reusable tooling that came out of it, so a future attempt
+starts informed instead of repeating the dead ends.
+
+## Goal
+
+Produce a stronger `TurboEngine` (v4) by improving only the *evaluation*
+(training data + learned features), not the search, while keeping the
+pure-Python leaf. Acceptance was a fair head-to-head benchmark vs a frozen v3
+snapshot with a positive Elo beyond ~2× standard error, plus a leaf-speed gate.
+
+## What was built (all reviewed, all green)
+
+The engine/trainer changes were implemented and unit-tested even though they
+did not yield a strength win:
+
+- **Tapered mg/eg evaluation** — every learned weight packs a middlegame and
+  endgame value into one int; the leaf accumulates a packed sum with the same
+  number of lookups as v3 and blends by a men-count phase. Verified
+  score-identical to v3 when loaded with v3's (non-tapered) weights.
+- **Learned king PST** — the king lookup tables can be filled from trained
+  values instead of the hand table.
+- **Tall 2×4 patterns** — six additional vertical men patterns beside v3's
+  eleven horizontal 4×2 patterns.
+- **`TPW2` weights format** — carries per-pattern (mg, eg) plus king PST;
+  loader keeps `TPW1` back-compat (reads as mg = eg, no king override), so a
+  missing/old file behaves exactly as v3.
+- **Upgraded offline trainer** — sparse COO features (phase + kings), Texel
+  position hygiene (dedup, drop opening plies, drop |eval| > 600cp,
+  phase-balance), 180° augmentation, a least-squares `scanreg` objective and a
+  result-blend objective.
+
+With the shipped v3 weights, the v4 code path plays **byte-identical** to v3
+(regression tests assert this), so none of the above changes behaviour on its
+own — the strength question is entirely about the trained weights.
+
+## Results
+
+All Elo figures are v4 minus frozen-v3, from `tools/benchmark_v4.py`
+(opening book, colour-swapped, parallel), with ±2·SE where SE is the standard
+error of the Elo estimate.
+
+### Iteration 1 — many shallow rollout labels
+
+Scan 3.1 self-play, 0.15 s/move, 40-ply rollouts, ~331k quiet positions.
+λ sweep, screened at 150 games @ 0.1 s:
+
+| λ    | Elo vs v3 | win% |
+|------|-----------|------|
+| 3e-3 | (worse)   | —    |
+| 1e-3 | −30       | 45.7 |
+| 3e-4 | +18       | 52.7 |
+| 1e-4 | −2        | 49.7 |
+
+Best (3e-4) at 0.3 s: −12. Net: **statistical parity with v3.** Lower training
+RMSE did **not** predict game strength (1e-4 had the best held-out RMSE but
+played even). Kings were starved in this data (few promotions in 40-ply
+rollouts), so the learned king PST was under-trained.
+
+### Iteration 2 — deeper, full-game labels
+
+0.5 s/move, full games (kings + real win/loss labels), ~78k positions
+(27.8% with a king, 48.9% decisive). Screened at 150 games @ 0.1 s:
+
+| candidate       | Elo vs v3 |
+|-----------------|-----------|
+| scanreg 3e-4    | −275      |
+| scanreg 1e-3    | −200      |
+| blend β0.4      | −223      |
+| blend β0.6      | −220      |
+
+**Much worse.** Same code as iteration 1 — only the data changed.
+
+### The root cause of the iteration-2 crash
+
+| data           | scan std | scan \|max\| | base std | scale a |
+|----------------|----------|--------------|----------|---------|
+| iter1 rollouts | 1.40     | 7.2          | 122 cp   | 84.7    |
+| iter2 full     | 24.74    | **100.0**    | **253 cp** | 7.0   |
+
+Full games reach lopsided, near-terminal positions where Scan's eval saturates
+to ±100 and material imbalance blows the base eval to 253 cp std. Tuning on
+decided positions distorts the eval for the balanced middlegame positions that
+actually decide games — the classic "remove positions with |score| > 600 cp and
+drop decided games" rule from Texel-tuning practice. The `|eval| > 600cp`
+hygiene did not save it because the Scan→cp scale collapsed to a = 7, leaving
+the whole distribution dominated by large evals.
+
+A merge experiment (iter1 balanced positions + only the balanced, king-bearing
+iter2 positions) returned to parity (−2 Elo) but was confounded: adding sparse
+low-men king buckets dropped the phase-balance median and over-capped the good
+midgame data (346k → 57k after cleaning).
+
+### Feature ablation (and a benchmark-noise lesson)
+
+Ablating the iteration-1 3e-4 candidate by weight-file surgery, 200 games @ 0.1 s:
+
+| variant             | Elo vs v3 |
+|---------------------|-----------|
+| full                | −14       |
+| taper off           | −17       |
+| **tall patterns off** | **+38** |
+| learned king off    | −4        |
+| king = v3 hand PST  | −7        |
+
+The +38 for "tall off" looked like a finding — but re-running at **300 games**
+it regressed to **−13** (and tall+king off to −37). At 150–200 games the ±45 Elo
+noise is larger than the ~20 Elo effects being chased; the +38 was a noise spike.
+**Lesson: use ≥300–500 games before believing a sub-40-Elo difference.**
+
+### Why it tops out at v3 (noise-free measurement)
+
+Rather than fight benchmark noise, we measured eval quality directly on 12,000
+held-out balanced positions (ground truth: 0.5 s Scan eval + game result):
+
+| eval     | Pearson vs deep-Scan | result-sign accuracy | result log-loss |
+|----------|----------------------|----------------------|-----------------|
+| v3       | 0.8503               | 0.9898               | 0.0317          |
+| v4 (3e-4)| 0.8578               | 0.9910               | 0.0304          |
+
+v4's eval **is** marginally more accurate — but only ~1% relative. That edge is
+below the noise floor in games and is erased by v4's ~1.4% slower leaf.
+
+### Last lever — slow time control
+
+If the small eval edge mattered anywhere it would be at deep search. iter1-3e-4
+vs v3 at **0.8 s/move, 400 games**: **−16.5 ± 31 Elo** (47.6% score). Deep search
+does not rescue it.
+
+## Conclusion
+
+Across three data regimes, λ sweeps, feature ablations, a result-blend
+objective, and time controls from 0.1 s to 0.8 s, the best result is
+**statistical parity with v3**. The shipped v3 pattern eval is already near the
+ceiling of what pattern-evaluation-trained-on-Scan-labels achieves; the extra
+capacity (taper, tall patterns, learned kings) is neutral-to-slightly-negative,
+and the ~1% eval-accuracy gain does not convert to Elo. This is a genuine
+ceiling of the *approach*, not a fixable bug.
+
+Leaf speed was never the blocker: the v4 eval profiled at 0.986× v3's nps
+(1.4% slower), well inside the ≤20% gate.
+
+## Recommendations for a future v5
+
+- A materially stronger eval needs a different function class — e.g. an **NNUE**
+  leaf. That breaks the pure-Python constraint (needs a C or optional-numpy
+  fast path), so it is a deliberate architecture decision, not a tuning knob.
+- Alternatively, invest in **search** (LMR/aspiration/move-ordering/TT tuning),
+  which at these fast time controls has more headroom than the eval.
+- If revisiting eval tuning: keep the **balanced rollout** distribution (never
+  full games), fix the phase-balance median sensitivity in `clean_samples`, and
+  budget for **≥500-game** benchmarks so real ~20-Elo effects clear the noise.
+
+## Reusable tooling produced
+
+- **`tools/profile_turbo.py`** — nodes/s profiler for any engine module over a
+  fixed position set; used for the leaf-speed gate.
+- **`tools/elo_benchmark.py`** — head-to-head benchmark that reports Elo with a
+  proper standard error and confidence interval (the missing piece in the
+  built-in `Benchmark`, which reports a point Elo only).
+
+The full experiment (v4 engine code, `TPW2`, the upgraded trainer, the
+`benchmark_v4.py`/ablation/eval-accuracy scripts) lives on the unmerged
+`engine/turbo-v4` branch as the record.

--- a/draughts/__init__.py
+++ b/draughts/__init__.py
@@ -57,11 +57,11 @@ from draughts.benchmark import STANDARD_OPENINGS, Benchmark, BenchmarkStats, Gam
 # AI/ML Support
 from draughts.boards.base import BoardFeatures
 from draughts.engines.agent import Agent, AgentEngine, BaseAgent
-from draughts.engines.alpha_beta import AlphaBetaEngine
 from draughts.engines.engine import Engine
 
 # Engines
 from draughts.engines.hub import HubEngine
+from draughts.engines.simple import SimpleEngine
 from draughts.engines.turbo import TurboEngine
 from draughts.models import Color, Figure
 from draughts.move import Move
@@ -81,7 +81,7 @@ __all__ = [
     "FryskBoard",
     # Engines
     "Engine",
-    "AlphaBetaEngine",
+    "SimpleEngine",
     "TurboEngine",
     "HubEngine",
     # Agents (AI interface)

--- a/draughts/benchmark.py
+++ b/draughts/benchmark.py
@@ -2,10 +2,10 @@
 Benchmarking module for comparing draughts engines.
 
 Example:
-    >>> from draughts import Benchmark, AlphaBetaEngine
+    >>> from draughts import Benchmark, SimpleEngine
     >>> stats = Benchmark(
-    ...     AlphaBetaEngine(depth_limit=4),
-    ...     AlphaBetaEngine(depth_limit=6),
+    ...     SimpleEngine(depth_limit=4),
+    ...     SimpleEngine(depth_limit=6),
     ...     games=10
     ... ).run()
 """
@@ -334,8 +334,8 @@ class Benchmark:
     Benchmark two engines against each other.
 
     Example:
-        >>> from draughts import Benchmark, AlphaBetaEngine
-        >>> bench = Benchmark(AlphaBetaEngine(depth_limit=4), AlphaBetaEngine(depth_limit=6))
+        >>> from draughts import Benchmark, SimpleEngine
+        >>> bench = Benchmark(SimpleEngine(depth_limit=4), SimpleEngine(depth_limit=6))
         >>> print(bench.run())
     """
 
@@ -432,7 +432,7 @@ class Benchmark:
 
 
 if __name__ == "__main__":
-    from draughts import AlphaBetaEngine
+    from draughts import SimpleEngine
 
-    bench = Benchmark(AlphaBetaEngine(depth_limit=4), AlphaBetaEngine(depth_limit=6), workers=10)
+    bench = Benchmark(SimpleEngine(depth_limit=4), SimpleEngine(depth_limit=6), workers=10)
     print(bench.run())

--- a/draughts/engines/__init__.py
+++ b/draughts/engines/__init__.py
@@ -1,5 +1,5 @@
 from draughts.engines.agent import Agent, AgentEngine, BaseAgent
-from draughts.engines.alpha_beta import AlphaBetaEngine
 from draughts.engines.engine import Engine
 from draughts.engines.hub import HubEngine
+from draughts.engines.simple import SimpleEngine
 from draughts.engines.turbo import TurboEngine

--- a/draughts/engines/agent.py
+++ b/draughts/engines/agent.py
@@ -99,7 +99,7 @@ class BaseAgent(ABC):
             # Use with Benchmark
             stats = Benchmark(
                 MyAgent().as_engine(),
-                AlphaBetaEngine(depth_limit=4),
+                SimpleEngine(depth_limit=4),
                 games=10
             ).run()
         """
@@ -128,7 +128,7 @@ class AgentEngine(Engine):
 
         # Wrap and benchmark
         engine = AgentEngine(RandomAgent(), name="Random")
-        stats = Benchmark(engine, AlphaBetaEngine(depth_limit=4)).run()
+        stats = Benchmark(engine, SimpleEngine(depth_limit=4)).run()
 
     Example with BaseAgent::
 

--- a/draughts/engines/simple.py
+++ b/draughts/engines/simple.py
@@ -56,7 +56,7 @@ def _create_pst_king(num_squares: int, rows: int) -> np.ndarray:
     return pst
 
 
-class AlphaBetaEngine(Engine):
+class SimpleEngine(Engine):
     """
     AI engine using Negamax search with alpha-beta pruning.
 
@@ -83,16 +83,16 @@ class AlphaBetaEngine(Engine):
         nodes: Number of nodes searched in last call.
 
     Example:
-        >>> from draughts import Board, AlphaBetaEngine
+        >>> from draughts import Board, SimpleEngine
         >>> board = Board()
-        >>> engine = AlphaBetaEngine(depth_limit=5)
+        >>> engine = SimpleEngine(depth_limit=5)
         >>> move = engine.get_best_move(board)
         >>> board.push(move)
 
     Example with American Draughts:
         >>> from draughts.boards.american import Board
         >>> board = Board()
-        >>> engine = AlphaBetaEngine(depth_limit=6)
+        >>> engine = SimpleEngine(depth_limit=6)
         >>> move = engine.get_best_move(board)
 
     Example with evaluation:
@@ -114,8 +114,8 @@ class AlphaBetaEngine(Engine):
             name: Custom engine name. Defaults to class name.
 
         Example:
-            >>> engine = AlphaBetaEngine(depth_limit=6)
-            >>> engine = AlphaBetaEngine(depth_limit=20, time_limit=1.0)
+            >>> engine = SimpleEngine(depth_limit=6)
+            >>> engine = SimpleEngine(depth_limit=20, time_limit=1.0)
         """
         self.depth_limit = depth_limit
         self.time_limit = time_limit

--- a/draughts/engines/turbo.py
+++ b/draughts/engines/turbo.py
@@ -50,6 +50,7 @@ from draughts.move import Move
 # perft in tests.
 # ---------------------------------------------------------------------------
 
+
 def _build_layout() -> tuple[tuple[int, ...], dict[int, int], int]:
     sq_to_bit: list[int] = []
     bit = 0
@@ -163,8 +164,8 @@ WM_T, WK_T, BM_T, BK_T = _build_eval_tables()
 # ---------------------------------------------------------------------------
 
 PAT_TRITS = 8
-PAT_ENTRIES = 3 ** PAT_TRITS  # 6561
-_POW3 = tuple(3 ** i for i in range(PAT_TRITS))
+PAT_ENTRIES = 3**PAT_TRITS  # 6561
+_POW3 = tuple(3**i for i in range(PAT_TRITS))
 
 
 def _build_patterns() -> tuple[tuple[int, ...], ...]:
@@ -173,8 +174,7 @@ def _build_patterns() -> tuple[tuple[int, ...], ...]:
 
     def block(r: int, c0: int) -> tuple[int, ...]:
         return tuple(
-            [r * 5 + c for c in range(c0, c0 + 4)]
-            + [(r + 1) * 5 + c for c in range(c0, c0 + 4)]
+            [r * 5 + c for c in range(c0, c0 + 4)] + [(r + 1) * 5 + c for c in range(c0, c0 + 4)]
         )
 
     pats: list[tuple[int, ...]] = []
@@ -245,12 +245,8 @@ def _load_pattern_weights() -> tuple[tuple[int, ...], ...]:
         n_pat, n_ent = struct.unpack_from("<HH", data, 4)
         if n_pat != N_PATTERNS or n_ent != PAT_ENTRIES:
             return zeros
-        vals = struct.unpack_from(
-            "<%dh" % (n_pat * n_ent), data, 8
-        )
-        return tuple(
-            tuple(vals[p * n_ent : (p + 1) * n_ent]) for p in range(n_pat)
-        )
+        vals = struct.unpack_from(f"<{n_pat * n_ent}h", data, 8)
+        return tuple(tuple(vals[p * n_ent : (p + 1) * n_ent]) for p in range(n_pat))
     except (OSError, struct.error):
         return zeros
 
@@ -296,12 +292,8 @@ def _evaluate(wm: int, wk: int, bm: int, bk: int, white_to_move: bool) -> int:
     # Left/right balance: lopsided formations are weak.
     w_all = wm | wk
     b_all = bm | bk
-    score -= SKEW_WEIGHT * abs(
-        (w_all & LEFT_MASK).bit_count() - (w_all & RIGHT_MASK).bit_count()
-    )
-    score += SKEW_WEIGHT * abs(
-        (b_all & LEFT_MASK).bit_count() - (b_all & RIGHT_MASK).bit_count()
-    )
+    score -= SKEW_WEIGHT * abs((w_all & LEFT_MASK).bit_count() - (w_all & RIGHT_MASK).bit_count())
+    score += SKEW_WEIGHT * abs((b_all & LEFT_MASK).bit_count() - (b_all & RIGHT_MASK).bit_count())
     # Trained pattern correction over MEN (white-perspective). Skipped when
     # weights are all zero so a missing weights file costs nothing.
     if PAT_ACTIVE:
@@ -322,6 +314,7 @@ def _evaluate(wm: int, wk: int, bm: int, bk: int, white_to_move: bool) -> int:
 # ---------------------------------------------------------------------------
 # Move generation (internal move = (from_bit, to_bit, captured_bitboard))
 # ---------------------------------------------------------------------------
+
 
 def _man_capture_dfs(
     frm: int,
@@ -401,9 +394,7 @@ def _king_capture_dfs(
     return extended
 
 
-def _gen_captures(
-    wm: int, wk: int, bm: int, bk: int, white: bool
-) -> list[tuple[int, int, int]]:
+def _gen_captures(wm: int, wk: int, bm: int, bk: int, white: bool) -> list[tuple[int, int, int]]:
     if white:
         men, kings, enemy = wm, wk, bm | bk
     else:
@@ -450,9 +441,7 @@ def _gen_captures(
     return result
 
 
-def _gen_quiets(
-    wm: int, wk: int, bm: int, bk: int, white: bool
-) -> list[tuple[int, int, int]]:
+def _gen_quiets(wm: int, wk: int, bm: int, bk: int, white: bool) -> list[tuple[int, int, int]]:
     all_p = wm | wk | bm | bk
     empty = SQ_MASK ^ all_p
     moves: list[tuple[int, int, int]] = []
@@ -568,6 +557,7 @@ def _apply(
 # Search
 # ---------------------------------------------------------------------------
 
+
 class _Timeout(Exception):
     pass
 
@@ -633,9 +623,7 @@ class TurboEngine(Engine):
                 return legal[0], _evaluate(wm, wk, bm, bk, white) / 100.0
             return legal[0]
 
-        best_mv, score = self._search_root(
-            wm, wk, bm, bk, white, board.halfmove_clock
-        )
+        best_mv, score = self._search_root(wm, wk, bm, bk, white, board.halfmove_clock)
         move = self._match_move(best_mv, legal)
         if with_evaluation:
             return move, score / 100.0
@@ -650,14 +638,10 @@ class TurboEngine(Engine):
         self._path = set()
         if len(self.tt) > TT_MAX:
             self.tt.clear()
-        self._deadline = (
-            time.perf_counter() + self.time_limit if self.time_limit else None
-        )
+        self._deadline = time.perf_counter() + self.time_limit if self.time_limit else None
         max_depth = self.depth_limit or 64
 
-        moves = _gen_captures(wm, wk, bm, bk, white) or _gen_quiets(
-            wm, wk, bm, bk, white
-        )
+        moves = _gen_captures(wm, wk, bm, bk, white) or _gen_quiets(wm, wk, bm, bk, white)
         best_mv = moves[0]
         best_score = -INF
         score = 0
@@ -802,9 +786,7 @@ class TurboEngine(Engine):
             try:
                 for mv in moves:
                     nwm, nwk, nbm, nbk, _ = _apply(wm, wk, bm, bk, white, mv)
-                    sc = -self._negamax(
-                        nwm, nwk, nbm, nbk, not white, 0, -beta, -alpha, ply + 1, 0
-                    )
+                    sc = -self._negamax(nwm, nwk, nbm, nbk, not white, 0, -beta, -alpha, ply + 1, 0)
                     if sc > best:
                         best = sc
                     if sc > alpha:
@@ -821,12 +803,7 @@ class TurboEngine(Engine):
 
         # Scan-style forward pruning: shallow verification search at a
         # raised beta (draughts substitute for null-move pruning).
-        if (
-            depth >= 3
-            and not captures
-            and beta < MATE - 512
-            and beta > -(MATE - 512)
-        ):
+        if depth >= 3 and not captures and beta < MATE - 512 and beta > -(MATE - 512):
             margin = 10 * depth
             new_beta = beta + margin
             v_depth = depth * 2 // 5
@@ -843,12 +820,11 @@ class TurboEngine(Engine):
                 if tt_move is not None and tt_move in moves:
                     moves.sort(key=lambda m: m != tt_move)
             else:
+
                 def order(m, _h=hist, _tt=tt_move):
                     if m == _tt:
                         return -HIST_MAX - 1
-                    return -_h[
-                        ((m[0].bit_length() - 1) << 6) | (m[1].bit_length() - 1)
-                    ]
+                    return -_h[((m[0].bit_length() - 1) << 6) | (m[1].bit_length() - 1)]
 
                 moves.sort(key=order)
 
@@ -869,18 +845,42 @@ class TurboEngine(Engine):
 
                 if i == 0:
                     sc = -self._negamax(
-                        nwm, nwk, nbm, nbk, not white, new_depth, -beta, -alpha,
-                        ply + 1, nhm,
+                        nwm,
+                        nwk,
+                        nbm,
+                        nbk,
+                        not white,
+                        new_depth,
+                        -beta,
+                        -alpha,
+                        ply + 1,
+                        nhm,
                     )
                 else:
                     sc = -self._negamax(
-                        nwm, nwk, nbm, nbk, not white, new_depth - red,
-                        -alpha - 1, -alpha, ply + 1, nhm,
+                        nwm,
+                        nwk,
+                        nbm,
+                        nbk,
+                        not white,
+                        new_depth - red,
+                        -alpha - 1,
+                        -alpha,
+                        ply + 1,
+                        nhm,
                     )
                     if sc > alpha and (red or sc < beta):
                         sc = -self._negamax(
-                            nwm, nwk, nbm, nbk, not white, new_depth, -beta, -alpha,
-                            ply + 1, nhm,
+                            nwm,
+                            nwk,
+                            nbm,
+                            nbk,
+                            not white,
+                            new_depth,
+                            -beta,
+                            -alpha,
+                            ply + 1,
+                            nhm,
                         )
                 if sc > best:
                     best = sc
@@ -892,15 +892,11 @@ class TurboEngine(Engine):
                     flag = TT_FLAG_LOWER
                     if not captures:
                         hist = self.hist
-                        idx = ((mv[0].bit_length() - 1) << 6) | (
-                            mv[1].bit_length() - 1
-                        )
+                        idx = ((mv[0].bit_length() - 1) << 6) | (mv[1].bit_length() - 1)
                         hist[idx] += (HIST_MAX - hist[idx]) >> 5
                         for j in range(i):
                             pm = moves[j]
-                            idx = ((pm[0].bit_length() - 1) << 6) | (
-                                pm[1].bit_length() - 1
-                            )
+                            idx = ((pm[0].bit_length() - 1) << 6) | (pm[1].bit_length() - 1)
                             hist[idx] -= hist[idx] >> 5
                     break
         finally:
@@ -931,9 +927,7 @@ class TurboEngine(Engine):
         """Quiet leaf: stand pat, unless the opponent threatens a capture -
         then spend one real ply so hanging pieces are seen (Scan's 'dodge')."""
         if allow_threat_ext and ply < 48 and _has_capture(wm, wk, bm, bk, not white):
-            return self._negamax(
-                wm, wk, bm, bk, white, 1, alpha, beta, ply, 0
-            )
+            return self._negamax(wm, wk, bm, bk, white, 1, alpha, beta, ply, 0)
         return _evaluate(wm, wk, bm, bk, white)
 
     # -- board conversion ---------------------------------------------------
@@ -981,6 +975,7 @@ class TurboEngine(Engine):
 # ---------------------------------------------------------------------------
 # Perft (used by tests to validate the internal move generator)
 # ---------------------------------------------------------------------------
+
 
 def perft(wm: int, wk: int, bm: int, bk: int, white: bool, depth: int) -> int:
     if depth == 0:

--- a/draughts/server/server.py
+++ b/draughts/server/server.py
@@ -347,11 +347,11 @@ if __name__ == "__main__":
     logger.add(sys.stderr, level="DEBUG")
 
     from draughts import HubEngine, StandardBoard
-    from draughts.engines import AlphaBetaEngine
+    from draughts.engines import SimpleEngine
 
     # Example: Two engines playing against each other
-    white_engine = AlphaBetaEngine(depth_limit=9)
-    black_engine = AlphaBetaEngine(depth_limit=9)
+    white_engine = SimpleEngine(depth_limit=9)
+    black_engine = SimpleEngine(depth_limit=9)
     # black_engine = HubEngine('./scan_engine/scan.exe', depth_limit=6)
 
     board = StandardBoard()

--- a/examples/custom_agents.py
+++ b/examples/custom_agents.py
@@ -12,7 +12,7 @@ from typing import Callable
 
 from draughts import (
     AgentEngine,
-    AlphaBetaEngine,
+    SimpleEngine,
     BaseAgent,
     Benchmark,
     Board,

--- a/examples/reinforcement_learning.py
+++ b/examples/reinforcement_learning.py
@@ -1,6 +1,6 @@
 """
 Reinforcement Learning Example - Eval-Based Training.
-Uses AlphaBetaEngine.get_eval() for dense reward signal.
+Uses SimpleEngine.get_eval() for dense reward signal.
 """
 import random
 import numpy as np
@@ -14,7 +14,7 @@ except ImportError:
     print("pip install torch")
     exit(1)
 
-from draughts import Color, AlphaBetaEngine
+from draughts import Color, SimpleEngine
 from draughts.boards.american import Board
 from draughts.benchmark import Benchmark
 
@@ -50,7 +50,7 @@ class NNEngine:
             return board.index_to_move(logits[0].argmax().item())
 
 
-def collect_eval_data(engine: AlphaBetaEngine, n_games=200):
+def collect_eval_data(engine: SimpleEngine, n_games=200):
     """Collect (state, action, eval) from engine self-play."""
     data = []
     for _ in range(n_games):
@@ -162,12 +162,12 @@ def eval_vs(net, opponent, n=100):
 
 
 def train():
-    engine = AlphaBetaEngine(depth_limit=4)
+    engine = SimpleEngine(depth_limit=4)
     net = PolicyNet()
     best_wr, best_state = 0, None
     
     # Phase 1: Supervised Learning from engine moves + evals
-    print("Phase 1: Learning from AlphaBeta(depth=4) moves + evals")
+    print("Phase 1: Learning from SimpleEngine(depth=4) moves + evals")
     print("=" * 65)
     print("Collecting training data with evaluations...")
     data = collect_eval_data(engine, n_games=300)
@@ -224,5 +224,5 @@ if __name__ == "__main__":
     net = train()
     
     print("\n" + "=" * 60)
-    print("Final Benchmark: NeuralNet vs AlphaBeta(depth=2)")
-    print(Benchmark(NNEngine(net), AlphaBetaEngine(depth_limit=2), board_class=Board, games=20).run())
+    print("Final Benchmark: NeuralNet vs SimpleEngine(depth=2)")
+    print(Benchmark(NNEngine(net), SimpleEngine(depth_limit=2), board_class=Board, games=20).run())

--- a/examples/simple_vs_scan.py
+++ b/examples/simple_vs_scan.py
@@ -1,11 +1,11 @@
 """
-Example: AlphaBeta engine vs Scan engine (Hub protocol)
+Example: SimpleEngine vs Scan engine (Hub protocol)
 
-This script plays a game between the built-in AlphaBeta engine and
+This script plays a game between the built-in SimpleEngine and
 an external Scan engine using the Hub protocol.
 
 Usage:
-    python alphabeta_vs_scan.py [path_to_scan.exe]
+    python simple_vs_scan.py [path_to_scan.exe]
 
 Requirements:
     - Scan draughts engine (https://hjetten.home.xs4all.nl/scan/scan.html)
@@ -19,13 +19,13 @@ import sys
 logger.add(sys.stderr, level="DEBUG")
 
 from draughts import StandardBoard, Color
-from draughts.engines import AlphaBetaEngine
+from draughts.engines import SimpleEngine
 from draughts.engines import HubEngine
 
 
 def play_game(scan_path: str, max_moves: int = 100) -> None:
     """
-    Play a game between AlphaBeta (White) and Scan (Black).
+    Play a game between SimpleEngine (White) and Scan (Black).
     
     Args:
         scan_path: Path to the Scan executable
@@ -33,8 +33,8 @@ def play_game(scan_path: str, max_moves: int = 100) -> None:
     """
     board = StandardBoard()
     
-    # AlphaBeta plays White
-    alphabeta = AlphaBetaEngine(depth_limit=9)
+    # SimpleEngine plays White
+    engine = SimpleEngine(depth_limit=9)
     
     # Scan plays Black
     print(f"Starting Scan engine from: {scan_path}")
@@ -43,7 +43,7 @@ def play_game(scan_path: str, max_moves: int = 100) -> None:
         scan.new_game()
         
         print("\n=== Game Start ===")
-        print(f"White: AlphaBeta (depth_limit=9)")
+        print(f"White: SimpleEngine (depth_limit=9)")
         print(f"Black: {scan.info.name} {scan.info.version}")
         print()
         
@@ -53,9 +53,9 @@ def play_game(scan_path: str, max_moves: int = 100) -> None:
             move_count += 1
             
             if board.turn == Color.WHITE:
-                # AlphaBeta's turn
-                move, score = alphabeta.get_best_move(board, with_evaluation=True)
-                print(f"{move_count}. White (AlphaBeta): {move} (eval: {score:+.2f})")
+                # SimpleEngine's turn
+                move, score = engine.get_best_move(board, with_evaluation=True)
+                print(f"{move_count}. White (SimpleEngine): {move} (eval: {score:+.2f})")
             else:
                 # Scan's turn
                 move, score = scan.get_best_move(board, with_evaluation=True)
@@ -99,7 +99,7 @@ def main():
                 break
         
         if scan_path is None:
-            print("Usage: python alphabeta_vs_scan.py <path_to_scan.exe>")
+            print("Usage: python simple_vs_scan.py <path_to_scan.exe>")
             print("\nScan engine not found. Please provide the path to scan.exe")
             print("Download Scan from: https://hjetten.home.xs4all.nl/scan/scan.html")
             sys.exit(1)

--- a/examples/train_value_net.py
+++ b/examples/train_value_net.py
@@ -24,7 +24,7 @@ this example is that **data quality matters far more than network size**:
 Teacher: Scan 3.1 (10x10 International draughts) by Fabien Letouzey. Download
 https://hjetten.home.xs4all.nl/scan/scan_31.zip, unzip it, and set the ``SCAN_EXE``
 environment variable to the extracted ``scan.exe``. Without Scan the script falls
-back to the built-in :class:`AlphaBetaEngine` (a weaker teacher, but it still runs).
+back to the built-in :class:`SimpleEngine` (a weaker teacher, but it still runs).
 
 Note on augmentation: unlike chess, a 10x10 draughts board has **no** left-right
 mirror symmetry on its playable squares (reflecting the columns flips square colour,
@@ -47,7 +47,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from loguru import logger
 
-from draughts import AlphaBetaEngine, BaseAgent, Benchmark, Color
+from draughts import SimpleEngine, BaseAgent, Benchmark, Color
 from draughts.boards.standard import Board  # 10x10 International draughts
 
 logger.remove()  # silence the library's per-move info logging for a clean run
@@ -110,7 +110,7 @@ class ValueNet(nn.Module):
 
 
 def make_teacher():
-    """Return a strong teacher engine: Scan if available, else built-in AlphaBeta."""
+    """Return a strong teacher engine: Scan if available, else built-in SimpleEngine."""
     if SCAN_EXE and Path(SCAN_EXE).exists():
         from draughts.engines.hub import HubEngine
 
@@ -119,8 +119,8 @@ def make_teacher():
         eng.start()
         print(f"  teacher: {eng.info.name} {eng.info.version}")
         return eng
-    print("  teacher: AlphaBetaEngine (Scan not found; set SCAN_EXE for a stronger net)")
-    return AlphaBetaEngine(depth_limit=6)
+    print("  teacher: SimpleEngine (Scan not found; set SCAN_EXE for a stronger net)")
+    return SimpleEngine(depth_limit=6)
 
 
 def collect_data(teacher) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
@@ -277,6 +277,6 @@ if __name__ == "__main__":
     agent = ValueAgent(net, depth=3)
     for depth in (2, 4, 6):
         stats = Benchmark(
-            agent.as_engine(), AlphaBetaEngine(depth_limit=depth), board_class=Board, games=20
+            agent.as_engine(), SimpleEngine(depth_limit=depth), board_class=Board, games=20
         ).run()
-        print(f"   vs AlphaBeta(depth={depth}): {stats}")
+        print(f"   vs SimpleEngine(depth={depth}): {stats}")

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@
 [![Python](https://img.shields.io/pypi/pyversions/py-draughts.svg)](https://pypi.org/project/py-draughts/)
 [![License](https://img.shields.io/badge/license-GPL--3.0-blue.svg)](LICENSE)
 
-**py-draughts** (import name: `draughts`) is a fast, modern Python library for **draughts** (also known as **checkers**). Bitboard-backed move generation, PDN/FEN parsing, a built-in alpha-beta engine, HUB protocol bridge for external engines like [Scan](https://hjetten.home.xs4all.nl/scan/scan.html) and [Kingsrow](http://www.edgilbert.org/Checkers/KingsRow.htm), an interactive web UI, and tensor exports for RL / ML — all in one package.
+**py-draughts** (import name: `draughts`) is a fast, modern Python library for **draughts** (also known as **checkers**). Bitboard-backed move generation, PDN/FEN parsing, built-in engines (the ML-trained `TurboEngine` plus a general-purpose `SimpleEngine`), a HUB protocol bridge for external engines like [Scan](https://hjetten.home.xs4all.nl/scan/scan.html) and [Kingsrow](http://www.edgilbert.org/Checkers/KingsRow.htm), an interactive web UI, and tensor exports for RL / ML — all in one package.
 
 > [!IMPORTANT]
 > The fastest pure-Python draughts library: **~200x faster** legal-move generation than [pydraughts](https://pypi.org/project/pydraughts/), with 8 supported variants and 260+ tests.
@@ -21,7 +21,7 @@
 | Board init | **3.3 µs** | 579.45 µs (**176x slower**) |
 | FEN parse | **27.4 µs** | 295.10 µs (**11x slower**) |
 | Variants | 8 (Standard, American, Frisian, Russian, Brazilian, Antidraughts, Breakthrough, Frysk!) | 6 |
-| Built-in AI engine | ✅ Alpha-beta + transposition tables | ❌ External only |
+| Built-in AI engine | ✅ TurboEngine (learned eval) + SimpleEngine (all variants) | ❌ External only |
 | Engine benchmarking suite | ✅ | ❌ |
 | Web UI | ✅ FastAPI + interactive board | ❌ |
 | SVG rendering | ✅ | ❌ |
@@ -202,35 +202,34 @@ False
 
 ## [Engine](https://miskibin.github.io/py-draughts/engine.html)
 
-Built-in alpha-beta engine with transposition tables and iterative deepening:
+Two built-in engines.
 
-```python
->>> from draughts import Board, AlphaBetaEngine
-
->>> board = Board()
->>> engine = AlphaBetaEngine(depth_limit=5)
-
->>> move = engine.get_best_move(board)
->>> move
-Move: 32->28
-
->>> move, score = engine.get_best_move(board, with_evaluation=True)
->>> score
-0.15
-```
-
-### TurboEngine (strongest built-in)
+### TurboEngine (strongest, recommended)
 
 For the standard international (10x10) board, `TurboEngine` combines Scan's
 63-bit bitboard layout, a PVS search, and a machine-learned pattern evaluation
-trained on Scan self-play. At equal time per move it beats `AlphaBetaEngine`
-by several hundred Elo while using less time:
+trained on Scan self-play — it is the strongest built-in engine:
 
 ```python
 >>> from draughts import Board, TurboEngine
 
 >>> engine = TurboEngine(time_limit=0.5)  # or depth_limit=...
 >>> move, score = engine.get_best_move(Board(), with_evaluation=True)
+```
+
+### SimpleEngine (all variants)
+
+`SimpleEngine` is a lightweight general-purpose engine — alpha-beta with
+transposition tables and iterative deepening — that works on **every variant**
+(`TurboEngine` is international-only):
+
+```python
+>>> from draughts import Board, SimpleEngine
+
+>>> engine = SimpleEngine(depth_limit=5)
+>>> move, score = engine.get_best_move(Board(), with_evaluation=True)
+>>> score
+0.15
 ```
 
 ### External Engines (Hub Protocol)
@@ -257,20 +256,20 @@ Compatible engines:
 Compare engines against each other with comprehensive statistics:
 
 ```python
->>> from draughts import Benchmark, AlphaBetaEngine
+>>> from draughts import Benchmark, SimpleEngine
 
 >>> stats = Benchmark(
-...     AlphaBetaEngine(depth_limit=4),
-...     AlphaBetaEngine(depth_limit=6),
+...     SimpleEngine(depth_limit=4),
+...     SimpleEngine(depth_limit=6),
 ...     games=20
 ... ).run()
 
 >>> print(stats)
 ============================================================
-  BENCHMARK: AlphaBetaEngine (d=4) vs AlphaBetaEngine (d=6)
+  BENCHMARK: SimpleEngine (d=4) vs SimpleEngine (d=6)
 ============================================================
   RESULTS: 2-12-6 (W-L-D)
-  AlphaBetaEngine (d=4) win rate: 25.0%
+  SimpleEngine (d=4) win rate: 25.0%
   Elo difference: -191
   ...
 ```
@@ -291,7 +290,7 @@ Build custom agents with neural networks, MCTS, or any algorithm:
 >>> move = agent.select_move(board)
 
 # Use with Benchmark
->>> stats = Benchmark(agent.as_engine(), AlphaBetaEngine(depth_limit=4), games=10).run()
+>>> stats = Benchmark(agent.as_engine(), SimpleEngine(depth_limit=4), games=10).run()
 ```
 
 **ML-ready features:**
@@ -330,9 +329,9 @@ plus the 180° augmentation. Same ~630K params, ~0.2 s/move (25–40 games each)
 
 | Opponent | Result (W–L–D) | Verdict |
 |----------|:--------------:|---------|
-| `AlphaBeta(depth=2)` | **22–2–1**   | dominates |
-| `AlphaBeta(depth=4)` | **27–2–11**  | dominates (was 15–3–12 without features) |
-| `AlphaBeta(depth=6)` | **11–9–5**   | now ahead of a depth‑6 search |
+| `SimpleEngine(depth=2)` | **22–2–1**   | dominates |
+| `SimpleEngine(depth=4)` | **27–2–11**  | dominates (was 15–3–12 without features) |
+| `SimpleEngine(depth=6)` | **11–9–5**   | now ahead of a depth‑6 search |
 
 Load the trained weights and play:
 
@@ -408,11 +407,11 @@ Scan it falls back to the built-in engine as a weaker teacher.
 Interactive web interface for playing and engine testing:
 
 ```python
-from draughts import Board, Server, AlphaBetaEngine, HubEngine
+from draughts import Board, Server, SimpleEngine, HubEngine
 
 server = Server(
     board=Board(),
-    white_engine=AlphaBetaEngine(depth_limit=6),
+    white_engine=SimpleEngine(depth_limit=6),
     black_engine=HubEngine("path/to/scan.exe", time_limit=1.0)
 )
 server.run() # Open http://localhost:8000

--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -4,7 +4,6 @@ import pytest
 
 from draughts import (
     STANDARD_OPENINGS,
-    AlphaBetaEngine,
     AmericanBoard,
     Benchmark,
     BenchmarkStats,
@@ -12,6 +11,7 @@ from draughts import (
     FrisianBoard,
     GameResult,
     RussianBoard,
+    SimpleEngine,
     StandardBoard,
 )
 from draughts.benchmark import _engine_label
@@ -93,29 +93,29 @@ class TestEngineLabel:
     """Tests for engine labeling."""
 
     def test_label_with_depth(self):
-        engine = AlphaBetaEngine(depth_limit=5)
+        engine = SimpleEngine(depth_limit=5)
         label = _engine_label(engine)
         assert "d=5" in label
-        assert "AlphaBetaEngine" in label
+        assert "SimpleEngine" in label
 
     def test_label_with_time(self):
-        engine = AlphaBetaEngine(depth_limit=None, time_limit=2.0)
+        engine = SimpleEngine(depth_limit=None, time_limit=2.0)
         label = _engine_label(engine)
         assert "t=2.0s" in label
 
     def test_label_with_both(self):
-        engine = AlphaBetaEngine(depth_limit=6, time_limit=1.0)
+        engine = SimpleEngine(depth_limit=6, time_limit=1.0)
         label = _engine_label(engine)
         assert "d=6" in label
         assert "t=1.0s" in label
 
     def test_label_with_suffix(self):
-        engine = AlphaBetaEngine(depth_limit=4)
+        engine = SimpleEngine(depth_limit=4)
         label = _engine_label(engine, " #1")
         assert label.endswith(" #1")
 
     def test_custom_name(self):
-        engine = AlphaBetaEngine(depth_limit=4, name="MyBot")
+        engine = SimpleEngine(depth_limit=4, name="MyBot")
         label = _engine_label(engine)
         assert "MyBot" in label
 
@@ -124,22 +124,22 @@ class TestBenchmarkInit:
     """Tests for Benchmark initialization."""
 
     def test_default_openings_standard(self):
-        e1 = AlphaBetaEngine(depth_limit=2)
-        e2 = AlphaBetaEngine(depth_limit=2)
+        e1 = SimpleEngine(depth_limit=2)
+        e2 = SimpleEngine(depth_limit=2)
         bench = Benchmark(e1, e2, board_class=StandardBoard)
         assert len(bench.openings) == len(STANDARD_OPENINGS)
 
     def test_default_openings_american(self):
         """Non-50 square boards should use starting position."""
-        e1 = AlphaBetaEngine(depth_limit=2)
-        e2 = AlphaBetaEngine(depth_limit=2)
+        e1 = SimpleEngine(depth_limit=2)
+        e2 = SimpleEngine(depth_limit=2)
         bench = Benchmark(e1, e2, board_class=AmericanBoard)
         assert len(bench.openings) == 1
         assert bench.openings[0][0] == "Start"
 
     def test_custom_openings(self):
-        e1 = AlphaBetaEngine(depth_limit=2)
-        e2 = AlphaBetaEngine(depth_limit=2)
+        e1 = SimpleEngine(depth_limit=2)
+        e2 = SimpleEngine(depth_limit=2)
         custom = ["W:W31,32:B1,2", "B:W40:B10"]
         bench = Benchmark(e1, e2, openings=custom)
         assert len(bench.openings) == 2
@@ -147,23 +147,23 @@ class TestBenchmarkInit:
         assert bench.openings[1][0] == "Custom 2"
 
     def test_same_name_engines_distinguished(self):
-        e1 = AlphaBetaEngine(depth_limit=3)
-        e2 = AlphaBetaEngine(depth_limit=5)
+        e1 = SimpleEngine(depth_limit=3)
+        e2 = SimpleEngine(depth_limit=5)
         bench = Benchmark(e1, e2)
         assert "d=3" in bench.e1_name
         assert "d=5" in bench.e2_name
         assert bench.e1_name != bench.e2_name
 
     def test_identical_engines_get_suffix(self):
-        e1 = AlphaBetaEngine(depth_limit=4)
-        e2 = AlphaBetaEngine(depth_limit=4)
+        e1 = SimpleEngine(depth_limit=4)
+        e2 = SimpleEngine(depth_limit=4)
         bench = Benchmark(e1, e2)
         assert "#1" in bench.e1_name
         assert "#2" in bench.e2_name
 
     def test_different_names_preserved(self):
-        e1 = AlphaBetaEngine(depth_limit=3, name="Bot1")
-        e2 = AlphaBetaEngine(depth_limit=5, name="Bot2")
+        e1 = SimpleEngine(depth_limit=3, name="Bot1")
+        e2 = SimpleEngine(depth_limit=5, name="Bot2")
         bench = Benchmark(e1, e2)
         assert bench.e1_name == "Bot1"
         assert bench.e2_name == "Bot2"
@@ -173,8 +173,8 @@ class TestBenchmarkRun:
     """Tests for running benchmarks."""
 
     def test_run_returns_stats(self):
-        e1 = AlphaBetaEngine(depth_limit=1)
-        e2 = AlphaBetaEngine(depth_limit=1)
+        e1 = SimpleEngine(depth_limit=1)
+        e2 = SimpleEngine(depth_limit=1)
         bench = Benchmark(e1, e2, games=2, max_moves=10)
         stats = bench.run()
 
@@ -183,8 +183,8 @@ class TestBenchmarkRun:
         assert len(stats.results) == 2
 
     def test_swap_colors(self):
-        e1 = AlphaBetaEngine(depth_limit=1)
-        e2 = AlphaBetaEngine(depth_limit=1)
+        e1 = SimpleEngine(depth_limit=1)
+        e2 = SimpleEngine(depth_limit=1)
         bench = Benchmark(e1, e2, games=4, max_moves=5, swap_colors=True)
         stats = bench.run()
 
@@ -193,24 +193,24 @@ class TestBenchmarkRun:
         assert Color.BLACK in colors
 
     def test_no_swap_colors(self):
-        e1 = AlphaBetaEngine(depth_limit=1)
-        e2 = AlphaBetaEngine(depth_limit=1)
+        e1 = SimpleEngine(depth_limit=1)
+        e2 = SimpleEngine(depth_limit=1)
         bench = Benchmark(e1, e2, games=3, max_moves=5, swap_colors=False)
         stats = bench.run()
 
         assert all(r.e1_color == Color.WHITE for r in stats.results)
 
     def test_max_moves_respected(self):
-        e1 = AlphaBetaEngine(depth_limit=1)
-        e2 = AlphaBetaEngine(depth_limit=1)
+        e1 = SimpleEngine(depth_limit=1)
+        e2 = SimpleEngine(depth_limit=1)
         bench = Benchmark(e1, e2, games=1, max_moves=10)
         stats = bench.run()
 
         assert stats.results[0].moves <= 10
 
     def test_game_numbers_sequential(self):
-        e1 = AlphaBetaEngine(depth_limit=1)
-        e2 = AlphaBetaEngine(depth_limit=1)
+        e1 = SimpleEngine(depth_limit=1)
+        e2 = SimpleEngine(depth_limit=1)
         bench = Benchmark(e1, e2, games=5, max_moves=5)
         stats = bench.run()
 
@@ -223,8 +223,8 @@ class TestBenchmarkBoardVariants:
 
     @pytest.mark.parametrize("board_class", [StandardBoard, AmericanBoard, RussianBoard])
     def test_board_variant(self, board_class):
-        e1 = AlphaBetaEngine(depth_limit=1)
-        e2 = AlphaBetaEngine(depth_limit=1)
+        e1 = SimpleEngine(depth_limit=1)
+        e2 = SimpleEngine(depth_limit=1)
         bench = Benchmark(e1, e2, board_class=board_class, games=1, max_moves=10)
         stats = bench.run()
 
@@ -233,8 +233,8 @@ class TestBenchmarkBoardVariants:
 
     def test_frisian_variant(self):
         """Frisian has different rules, verify it works."""
-        e1 = AlphaBetaEngine(depth_limit=1)
-        e2 = AlphaBetaEngine(depth_limit=1)
+        e1 = SimpleEngine(depth_limit=1)
+        e2 = SimpleEngine(depth_limit=1)
         bench = Benchmark(e1, e2, board_class=FrisianBoard, games=1, max_moves=10)
         stats = bench.run()
 
@@ -246,8 +246,8 @@ class TestBenchmarkOpenings:
 
     def test_openings_cycle(self):
         """Openings should cycle when games > openings."""
-        e1 = AlphaBetaEngine(depth_limit=1)
-        e2 = AlphaBetaEngine(depth_limit=1)
+        e1 = SimpleEngine(depth_limit=1)
+        e2 = SimpleEngine(depth_limit=1)
         # Only 2 custom openings, but 4 games
         bench = Benchmark(
             e1,
@@ -269,8 +269,8 @@ class TestBenchmarkOpenings:
 
     def test_invalid_opening_fen(self):
         """Invalid FEN should raise an error during game."""
-        e1 = AlphaBetaEngine(depth_limit=1)
-        e2 = AlphaBetaEngine(depth_limit=1)
+        e1 = SimpleEngine(depth_limit=1)
+        e2 = SimpleEngine(depth_limit=1)
 
         # This should raise when trying to parse invalid FEN
         with pytest.raises(Exception):
@@ -305,16 +305,16 @@ class TestEngineNameParameter:
     """Tests for engine name parameter."""
 
     def test_engine_default_name(self):
-        engine = AlphaBetaEngine(depth_limit=5)
-        assert engine.name == "AlphaBetaEngine"
+        engine = SimpleEngine(depth_limit=5)
+        assert engine.name == "SimpleEngine"
 
     def test_engine_custom_name(self):
-        engine = AlphaBetaEngine(depth_limit=5, name="MyCustomEngine")
+        engine = SimpleEngine(depth_limit=5, name="MyCustomEngine")
         assert engine.name == "MyCustomEngine"
 
     def test_benchmark_uses_custom_name(self):
-        e1 = AlphaBetaEngine(depth_limit=3, name="FastBot")
-        e2 = AlphaBetaEngine(depth_limit=5, name="StrongBot")
+        e1 = SimpleEngine(depth_limit=3, name="FastBot")
+        e2 = SimpleEngine(depth_limit=5, name="StrongBot")
         bench = Benchmark(e1, e2, games=1, max_moves=5)
         stats = bench.run()
 

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -1,17 +1,17 @@
 import pytest
 
 from draughts.boards.standard import Board as StandardBoard
-from draughts.engines import AlphaBetaEngine
+from draughts.engines import SimpleEngine
 from test._test_helpers import get_board, seeded_range, standard_board_after_random_play
 
 
-class TestAlphaBetaEngine:
-    """Test the AlphaBetaEngine optimizations."""
+class TestSimpleEngine:
+    """Test the SimpleEngine optimizations."""
 
     @pytest.fixture(autouse=True)
     def setup(self):
         self.board = get_board("standard")
-        self.engine = AlphaBetaEngine(depth_limit=3)
+        self.engine = SimpleEngine(depth_limit=3)
         yield
         del self.board
         del self.engine
@@ -97,7 +97,7 @@ def _snapshot(board: StandardBoard):
 @pytest.mark.parametrize("seed", list(seeded_range(15)))
 def test_engine_get_best_move_does_not_mutate_board(seed):
     board = standard_board_after_random_play(seed=seed, plies=30)
-    engine = AlphaBetaEngine(depth_limit=2)
+    engine = SimpleEngine(depth_limit=2)
 
     if board.game_over:
         return
@@ -117,7 +117,7 @@ def test_engine_get_best_move_does_not_mutate_board(seed):
 @pytest.mark.parametrize("seed", list(seeded_range(15)))
 def test_engine_hash_is_stable_across_push_pop(seed):
     board = standard_board_after_random_play(seed=seed, plies=25)
-    engine = AlphaBetaEngine(depth_limit=1)
+    engine = SimpleEngine(depth_limit=1)
 
     legal = list(board.legal_moves)
     if not legal:
@@ -133,7 +133,7 @@ def test_engine_hash_is_stable_across_push_pop(seed):
 @pytest.mark.parametrize("seed", list(seeded_range(10)))
 def test_engine_populates_transposition_table_for_root(seed):
     board = standard_board_after_random_play(seed=seed, plies=20)
-    engine = AlphaBetaEngine(depth_limit=2)
+    engine = SimpleEngine(depth_limit=2)
 
     if board.game_over:
         return
@@ -174,9 +174,9 @@ def _play_engine_vs_random(board, engine, engine_is_white: bool, seed: int) -> s
 @pytest.mark.parametrize("variant", ["standard", "american", "russian", "frisian"])
 @pytest.mark.parametrize("game_idx", range(5))
 def test_engine_depth1_beats_random(variant, game_idx):
-    """AlphaBeta depth-1 should consistently beat random moves."""
+    """SimpleEngine depth-1 should consistently beat random moves."""
     board = get_board(variant)
-    engine = AlphaBetaEngine(depth_limit=1)
+    engine = SimpleEngine(depth_limit=1)
 
     # Alternate colors
     engine_is_white = game_idx % 2 == 0

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.testclient import TestClient
 
-from draughts.engines import AlphaBetaEngine, Engine
+from draughts.engines import Engine, SimpleEngine
 from draughts.move import Move
 from draughts.server.server import Server
 from test._test_helpers import get_board
@@ -124,7 +124,7 @@ def test_set_depth_clamps_and_updates_engine():
     try:
         Server.APP = _new_test_app()
         board = get_board("standard")
-        engine = AlphaBetaEngine(depth_limit=6)
+        engine = SimpleEngine(depth_limit=6)
         server = Server(board=board, white_engine=engine, black_engine=engine)
         client = TestClient(server.APP)
 

--- a/test/test_turbo.py
+++ b/test/test_turbo.py
@@ -41,16 +41,13 @@ def _internal_moveset(board: Board):
             lsb = c & -c
             squares.add(B2S[lsb.bit_length() - 1])
             c ^= lsb
-        out.add(
-            (B2S[frm.bit_length() - 1], B2S[to.bit_length() - 1], frozenset(squares))
-        )
+        out.add((B2S[frm.bit_length() - 1], B2S[to.bit_length() - 1], frozenset(squares)))
     return out
 
 
 def _board_moveset(board: Board):
     return {
-        (m.square_list[0], m.square_list[-1], frozenset(m.captured_list))
-        for m in board.legal_moves
+        (m.square_list[0], m.square_list[-1], frozenset(m.captured_list)) for m in board.legal_moves
     }
 
 
@@ -74,8 +71,7 @@ def test_engine_returns_legal_move():
             break
         move = engine.get_best_move(board)
         assert any(
-            move.square_list == m.square_list
-            and move.captured_list == m.captured_list
+            move.square_list == m.square_list and move.captured_list == m.captured_list
             for m in board.legal_moves
         )
         board.push(move)
@@ -114,9 +110,7 @@ def test_engine_beats_random():
                 move = rng.choice(board.legal_moves)
             board.push(move)
         result = board.result
-        if (engine_is_white and result == "1-0") or (
-            not engine_is_white and result == "0-1"
-        ):
+        if (engine_is_white and result == "1-0") or (not engine_is_white and result == "0-1"):
             wins += 1
     assert wins == games
 

--- a/tools/depth_benchmark.py
+++ b/tools/depth_benchmark.py
@@ -12,7 +12,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from draughts.boards.standard import Board
-from draughts.engines import AlphaBetaEngine
+from draughts.engines import SimpleEngine
 
 # Test positions - mix of opening, midgame, and endgame
 TEST_POSITIONS = [
@@ -29,7 +29,7 @@ MOVES_PER_POSITION = 3  # Number of moves to make per position
 
 def benchmark_depth(depth: int) -> dict:
     """Benchmark engine at given depth, return stats."""
-    engine = AlphaBetaEngine(depth_limit=depth)
+    engine = SimpleEngine(depth_limit=depth)
 
     total_time = 0.0
     total_moves = 0

--- a/tools/elo_benchmark.py
+++ b/tools/elo_benchmark.py
@@ -12,7 +12,7 @@ Each engine is given as a spec string ``kind[:key=val...]``:
     turbo                      TurboEngine, default settings
     turbo:time=0.2             TurboEngine, 0.2s / move
     turbo:depth=8:name=deep    TurboEngine, fixed depth 8, labelled "deep"
-    alphabeta:depth=6          AlphaBetaEngine, depth 6
+    simple:depth=6          SimpleEngine, depth 6
 
 Examples::
 
@@ -20,8 +20,8 @@ Examples::
     python tools/elo_benchmark.py --e1 turbo:time=0.1 --e2 turbo:time=0.3 \
         --games 300 --workers 6
 
-    # TurboEngine vs the alpha-beta engine.
-    python tools/elo_benchmark.py --e1 turbo:time=0.2 --e2 alphabeta:depth=6 \
+    # TurboEngine vs the simple engine.
+    python tools/elo_benchmark.py --e1 turbo:time=0.2 --e2 simple:depth=6 \
         --games 100
 
 A positive Elo means ``--e1`` is stronger. ``significant`` is true when the
@@ -37,10 +37,10 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from draughts import AlphaBetaEngine, Benchmark, TurboEngine  # noqa: E402
+from draughts import Benchmark, SimpleEngine, TurboEngine  # noqa: E402
 from draughts.models import Color  # noqa: E402
 
-_KINDS = {"turbo": TurboEngine, "alphabeta": AlphaBetaEngine}
+_KINDS = {"turbo": TurboEngine, "simple": SimpleEngine}
 
 
 def build_engine(spec: str):
@@ -96,22 +96,28 @@ def elo_and_se(scores: list[float]) -> tuple[float, float]:
 
 
 def main():
-    ap = argparse.ArgumentParser(description=__doc__,
-                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     ap.add_argument("--e1", required=True, help="engine 1 spec (kind[:key=val...])")
     ap.add_argument("--e2", required=True, help="engine 2 spec (kind[:key=val...])")
     ap.add_argument("--games", type=int, default=100)
     ap.add_argument("--workers", type=int, default=1)
     ap.add_argument("--max-moves", type=int, default=200)
-    ap.add_argument("--no-swap", action="store_true",
-                    help="do not swap colours between games (default: swap)")
+    ap.add_argument(
+        "--no-swap", action="store_true", help="do not swap colours between games (default: swap)"
+    )
     ap.add_argument("--csv", default=None, help="append summary to this CSV path")
     args = ap.parse_args()
 
     e1, e2 = build_engine(args.e1), build_engine(args.e2)
     stats = Benchmark(
-        e1, e2, games=args.games, swap_colors=not args.no_swap,
-        max_moves=args.max_moves, workers=args.workers,
+        e1,
+        e2,
+        games=args.games,
+        swap_colors=not args.no_swap,
+        max_moves=args.max_moves,
+        workers=args.workers,
     ).run()
 
     scores = e1_scores(stats)
@@ -125,7 +131,9 @@ def main():
     print(f"  W-L-D (e1):  {stats.e1_wins}-{stats.e2_wins}-{stats.draws}")
     print(f"  e1 score:    {stats.e1_win_rate:.1%}")
     print(f"  Elo (e1-e2): {elo:+.1f}  +/- {two_se:.1f} (2 SE)")
-    print(f"  significant: {significant}  (|Elo| >= 2 SE, e1 {'stronger' if elo > 0 else 'weaker'})")
+    print(
+        f"  significant: {significant}  (|Elo| >= 2 SE, e1 {'stronger' if elo > 0 else 'weaker'})"
+    )
 
     if args.csv:
         stats.to_csv(args.csv)

--- a/tools/elo_benchmark.py
+++ b/tools/elo_benchmark.py
@@ -1,0 +1,136 @@
+"""Head-to-head engine benchmark with Elo *and* a standard error.
+
+The built-in :class:`draughts.Benchmark` reports a point Elo estimate. For
+deciding whether one engine is really stronger than another you need the
+uncertainty too: at a few hundred games the Elo noise is easily ±30-50, so a
+"+20 Elo" point estimate is often indistinguishable from zero. This tool wraps
+``Benchmark`` and adds the standard error, a 2-sigma interval, and a
+significance verdict.
+
+Each engine is given as a spec string ``kind[:key=val...]``:
+
+    turbo                      TurboEngine, default settings
+    turbo:time=0.2             TurboEngine, 0.2s / move
+    turbo:depth=8:name=deep    TurboEngine, fixed depth 8, labelled "deep"
+    alphabeta:depth=6          AlphaBetaEngine, depth 6
+
+Examples::
+
+    # Is TurboEngine at 0.1s stronger than at 0.3s? 300 games, 6 workers.
+    python tools/elo_benchmark.py --e1 turbo:time=0.1 --e2 turbo:time=0.3 \
+        --games 300 --workers 6
+
+    # TurboEngine vs the alpha-beta engine.
+    python tools/elo_benchmark.py --e1 turbo:time=0.2 --e2 alphabeta:depth=6 \
+        --games 100
+
+A positive Elo means ``--e1`` is stronger. ``significant`` is true when the
+estimate is at least two standard errors from zero.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from draughts import AlphaBetaEngine, Benchmark, TurboEngine  # noqa: E402
+from draughts.models import Color  # noqa: E402
+
+_KINDS = {"turbo": TurboEngine, "alphabeta": AlphaBetaEngine}
+
+
+def build_engine(spec: str):
+    """Parse ``kind[:key=val...]`` into an engine instance."""
+    parts = spec.split(":")
+    kind = parts[0].strip().lower()
+    if kind not in _KINDS:
+        raise SystemExit(f"unknown engine kind {kind!r}; choose from {list(_KINDS)}")
+    kwargs = {}
+    for p in parts[1:]:
+        if not p:
+            continue
+        k, _, v = p.partition("=")
+        k = k.strip()
+        if k == "time":
+            kwargs["time_limit"] = float(v)
+        elif k == "depth":
+            kwargs["depth_limit"] = int(v)
+        elif k == "name":
+            kwargs["name"] = v
+        else:
+            raise SystemExit(f"unknown engine param {k!r} in spec {spec!r}")
+    return _KINDS[kind](**kwargs)
+
+
+def e1_scores(stats) -> list[float]:
+    """Per-game score for engine 1: win 1.0, draw 0.5, loss 0.0."""
+    out = []
+    for r in stats.results:
+        if r.winner is None:
+            out.append(0.5)
+        elif r.winner == r.e1_color:
+            out.append(1.0)
+        else:
+            out.append(0.0)
+    return out
+
+
+def elo_and_se(scores: list[float]) -> tuple[float, float]:
+    """Return (elo, se_elo) for engine 1 from its per-game scores."""
+    n = len(scores)
+    if n == 0:
+        return 0.0, 0.0
+    p = sum(scores) / n
+    mean = p
+    var = sum((s - mean) ** 2 for s in scores) / n  # population variance of scores
+    se_p = math.sqrt(var / n) if n else 0.0
+    # Elo(p) = -400 log10(1/p - 1); dElo/dp = (400/ln10) / (p(1-p))
+    pc = min(max(p, 1e-6), 1 - 1e-6)
+    elo = -400.0 * math.log10(1.0 / pc - 1.0)
+    se_elo = (400.0 / math.log(10)) * se_p / max(p * (1.0 - p), 0.05)
+    return elo, se_elo
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--e1", required=True, help="engine 1 spec (kind[:key=val...])")
+    ap.add_argument("--e2", required=True, help="engine 2 spec (kind[:key=val...])")
+    ap.add_argument("--games", type=int, default=100)
+    ap.add_argument("--workers", type=int, default=1)
+    ap.add_argument("--max-moves", type=int, default=200)
+    ap.add_argument("--no-swap", action="store_true",
+                    help="do not swap colours between games (default: swap)")
+    ap.add_argument("--csv", default=None, help="append summary to this CSV path")
+    args = ap.parse_args()
+
+    e1, e2 = build_engine(args.e1), build_engine(args.e2)
+    stats = Benchmark(
+        e1, e2, games=args.games, swap_colors=not args.no_swap,
+        max_moves=args.max_moves, workers=args.workers,
+    ).run()
+
+    scores = e1_scores(stats)
+    elo, se = elo_and_se(scores)
+    two_se = 2.0 * se
+    significant = abs(elo) >= two_se and two_se > 0
+
+    print()
+    print(f"  {stats.e1_name}  vs  {stats.e2_name}")
+    print(f"  games:       {stats.games}")
+    print(f"  W-L-D (e1):  {stats.e1_wins}-{stats.e2_wins}-{stats.draws}")
+    print(f"  e1 score:    {stats.e1_win_rate:.1%}")
+    print(f"  Elo (e1-e2): {elo:+.1f}  +/- {two_se:.1f} (2 SE)")
+    print(f"  significant: {significant}  (|Elo| >= 2 SE, e1 {'stronger' if elo > 0 else 'weaker'})")
+
+    if args.csv:
+        stats.to_csv(args.csv)
+        print(f"  csv:         appended to {args.csv}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/generate_benchmark_charts.py
+++ b/tools/generate_benchmark_charts.py
@@ -25,7 +25,7 @@ except ImportError:
     import numpy as np
 
 from draughts.boards.standard import Board
-from draughts.engines import AlphaBetaEngine
+from draughts.engines import SimpleEngine
 
 
 def benchmark_legal_moves():
@@ -85,7 +85,7 @@ def benchmark_engine_depth(max_depth=10):
     results = []
 
     for depth in range(1, max_depth + 1):
-        engine = AlphaBetaEngine(depth_limit=depth)
+        engine = SimpleEngine(depth_limit=depth)
 
         total_time = 0.0
         total_moves = 0
@@ -188,7 +188,7 @@ def generate_charts(legal_moves_results, engine_results, output_dir):
 
     plt.xlabel("Search Depth", fontsize=12)
     plt.ylabel("Average Time per Move (ms)", fontsize=12)
-    plt.title("AlphaBeta Engine - Search Time by Depth", fontsize=14, fontweight="bold")
+    plt.title("SimpleEngine - Search Time by Depth", fontsize=14, fontweight="bold")
     plt.xticks(depths)
     plt.yscale("log")
     plt.grid(True, alpha=0.3)
@@ -214,7 +214,7 @@ def generate_charts(legal_moves_results, engine_results, output_dir):
 
     plt.xlabel("Search Depth", fontsize=12)
     plt.ylabel("Average Nodes Searched", fontsize=12)
-    plt.title("AlphaBeta Engine - Nodes Searched by Depth", fontsize=14, fontweight="bold")
+    plt.title("SimpleEngine - Nodes Searched by Depth", fontsize=14, fontweight="bold")
     plt.xticks(depths)
     plt.yscale("log")
     plt.grid(True, alpha=0.3)
@@ -240,7 +240,7 @@ def generate_charts(legal_moves_results, engine_results, output_dir):
     ax2.tick_params(axis="y", labelcolor=color2)
     ax2.set_yscale("log")
 
-    plt.title("AlphaBeta Engine Performance by Depth", fontsize=14, fontweight="bold")
+    plt.title("SimpleEngine Performance by Depth", fontsize=14, fontweight="bold")
     fig.tight_layout()
     plt.savefig(output_dir / "engine_benchmark.png", dpi=150)
     plt.close()

--- a/tools/profile_engine_detailed.py
+++ b/tools/profile_engine_detailed.py
@@ -5,14 +5,14 @@ import pstats
 from io import StringIO
 
 from draughts.boards.standard import Board
-from draughts.engines import AlphaBetaEngine
+from draughts.engines import SimpleEngine
 
 
 def run_benchmark(depth=4):
     """Run benchmark with configurable depth."""
     # Test with starting position
     board = Board()
-    engine = AlphaBetaEngine(depth_limit=depth)
+    engine = SimpleEngine(depth_limit=depth)
 
     # Get one move at specified depth
     move = engine.get_best_move(board)
@@ -32,7 +32,7 @@ def run_mid_game_benchmark(depth=4):
         if moves:
             board.push(moves[0])
 
-    engine = AlphaBetaEngine(depth_limit=depth)
+    engine = SimpleEngine(depth_limit=depth)
     print(f"\nMid-game position (after 6 moves):")
     print(board)
 

--- a/tools/profile_turbo.py
+++ b/tools/profile_turbo.py
@@ -1,0 +1,141 @@
+"""
+Profile TurboEngine performance: nodes per second over test positions.
+
+Usage:
+  python tools/profile_turbo.py --module draughts.engines.turbo --depth 7
+
+Outputs per-position and TOTAL nodes, time, and nps.
+"""
+
+import argparse
+import importlib
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+# Add project root to path (mirrors tools/generate_benchmark_charts.py) so
+# `tools.checkpoints.*` is importable and the repo's `draughts` package wins
+# over any foreign copy in site-packages.
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from draughts import Board  # noqa: E402
+
+
+# Test positions: opening, midgame, endgame-with-kings, complex
+TEST_POSITIONS = [
+    # Opening (starting position)
+    ('[FEN "W:W28,33,34,38,39,43,44,48,49,50:B5,6,7,8,9,10,14,15,19,20"]', "Opening"),
+
+    # Midgame
+    ('[FEN "W:W31,32,33,34,35:B16,17,18,19,20"]', "Midgame-A"),
+    ('[FEN "B:W24,28,29,30,33,34,38,39,44,45,49,50:B1,2,6,7,8,12,13,17,18,22,23,27"]', "Midgame-B"),
+
+    # King captures / tactical
+    ('[FEN "W:WK10:B14,15,24,25"]', "King Captures"),
+
+    # Complex positions
+    ('[FEN "W:W27,28,32,33,37,38,42,43,47,48:B3,4,8,9,13,14,18,19,23,24"]', "Complex"),
+
+    # Endgame with kings
+    ('[FEN "W:WK10,K20:BK30,K40"]', "Endgame-Kings-A"),
+    ('[FEN "B:WK15,K25:BK35,K45"]', "Endgame-Kings-B"),
+
+    # More midgame positions for stability
+    ('[FEN "W:W21,22,26,27,31,32:B14,15,19,20,24,25"]', "Midgame-C"),
+    ('[FEN "W:W30,31,35,36,40,41,45,46:B8,9,13,14,18,19,23,24"]', "Midgame-D"),
+
+    # Position with threats
+    ('[FEN "W:W18,22,23,27,28,32,33:B6,7,11,12,16,17"]', "Midgame-Threats"),
+]
+
+
+def load_engine_class(module_path: str):
+    """Dynamically import and return TurboEngine class from module path."""
+    try:
+        module = importlib.import_module(module_path)
+        return module.TurboEngine
+    except (ImportError, AttributeError) as e:
+        print(f"Error loading module {module_path}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def profile_position(engine, board: Board, position_name: str) -> tuple[int, float, Optional[float]]:
+    """
+    Profile a single position.
+
+    Returns: (nodes, secs, nps)
+    nps is None if engine doesn't expose node counter.
+    """
+    # Ensure engine starts clean
+    engine.nodes = 0
+
+    start = time.perf_counter()
+    move = engine.get_best_move(board)
+    elapsed = time.perf_counter() - start
+
+    nodes = getattr(engine, 'nodes', None)
+    nps = nodes / elapsed if nodes is not None and elapsed > 0 else None
+
+    return nodes, elapsed, nps
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Profile TurboEngine: report nodes, time, and nps per position"
+    )
+    parser.add_argument(
+        "--module",
+        required=True,
+        help="Module exposing a TurboEngine class (e.g., draughts.engines.turbo)"
+    )
+    parser.add_argument(
+        "--depth",
+        type=int,
+        default=7,
+        help="Search depth (default: 7)"
+    )
+    args = parser.parse_args()
+
+    # Load engine class
+    TurboEngine = load_engine_class(args.module)
+
+    # Initialize engine
+    engine = TurboEngine(depth_limit=args.depth)
+
+    print(f"# Profiling {args.module} at depth {args.depth}")
+    print(f"# {len(TEST_POSITIONS)} positions")
+    print()
+
+    total_nodes = 0
+    total_secs = 0.0
+    has_nodes = True
+
+    for fen, name in TEST_POSITIONS:
+        board = Board.from_fen(fen)
+        nodes, secs, nps = profile_position(engine, board, name)
+
+        if nodes is None:
+            has_nodes = False
+            if nps is not None:
+                print(f"{name:20} secs={secs:8.4f} nps={nps:10.0f}")
+            else:
+                print(f"{name:20} secs={secs:8.4f} nps=None")
+        else:
+            total_nodes += nodes
+            total_secs += secs
+            if nps is not None:
+                print(f"{name:20} nodes={nodes:10} secs={secs:8.4f} nps={nps:10.0f}")
+            else:
+                print(f"{name:20} nodes={nodes:10} secs={secs:8.4f} nps=None")
+
+    print()
+    if has_nodes:
+        total_nps = total_nodes / total_secs if total_secs > 0 else 0.0
+        print(f"TOTAL               nodes={total_nodes:10} secs={total_secs:8.4f} nps={total_nps:10.0f}")
+    else:
+        print(f"TOTAL               secs={total_secs:8.4f} nps=None")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/profile_turbo.py
+++ b/tools/profile_turbo.py
@@ -21,30 +21,23 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from draughts import Board  # noqa: E402
 
-
 # Test positions: opening, midgame, endgame-with-kings, complex
 TEST_POSITIONS = [
     # Opening (starting position)
     ('[FEN "W:W28,33,34,38,39,43,44,48,49,50:B5,6,7,8,9,10,14,15,19,20"]', "Opening"),
-
     # Midgame
     ('[FEN "W:W31,32,33,34,35:B16,17,18,19,20"]', "Midgame-A"),
     ('[FEN "B:W24,28,29,30,33,34,38,39,44,45,49,50:B1,2,6,7,8,12,13,17,18,22,23,27"]', "Midgame-B"),
-
     # King captures / tactical
     ('[FEN "W:WK10:B14,15,24,25"]', "King Captures"),
-
     # Complex positions
     ('[FEN "W:W27,28,32,33,37,38,42,43,47,48:B3,4,8,9,13,14,18,19,23,24"]', "Complex"),
-
     # Endgame with kings
     ('[FEN "W:WK10,K20:BK30,K40"]', "Endgame-Kings-A"),
     ('[FEN "B:WK15,K25:BK35,K45"]', "Endgame-Kings-B"),
-
     # More midgame positions for stability
     ('[FEN "W:W21,22,26,27,31,32:B14,15,19,20,24,25"]', "Midgame-C"),
     ('[FEN "W:W30,31,35,36,40,41,45,46:B8,9,13,14,18,19,23,24"]', "Midgame-D"),
-
     # Position with threats
     ('[FEN "W:W18,22,23,27,28,32,33:B6,7,11,12,16,17"]', "Midgame-Threats"),
 ]
@@ -60,7 +53,9 @@ def load_engine_class(module_path: str):
         sys.exit(1)
 
 
-def profile_position(engine, board: Board, position_name: str) -> tuple[int, float, Optional[float]]:
+def profile_position(
+    engine, board: Board, position_name: str
+) -> tuple[int, float, Optional[float]]:
     """
     Profile a single position.
 
@@ -74,7 +69,7 @@ def profile_position(engine, board: Board, position_name: str) -> tuple[int, flo
     move = engine.get_best_move(board)
     elapsed = time.perf_counter() - start
 
-    nodes = getattr(engine, 'nodes', None)
+    nodes = getattr(engine, "nodes", None)
     nps = nodes / elapsed if nodes is not None and elapsed > 0 else None
 
     return nodes, elapsed, nps
@@ -87,14 +82,9 @@ def main():
     parser.add_argument(
         "--module",
         required=True,
-        help="Module exposing a TurboEngine class (e.g., draughts.engines.turbo)"
+        help="Module exposing a TurboEngine class (e.g., draughts.engines.turbo)",
     )
-    parser.add_argument(
-        "--depth",
-        type=int,
-        default=7,
-        help="Search depth (default: 7)"
-    )
+    parser.add_argument("--depth", type=int, default=7, help="Search depth (default: 7)")
     args = parser.parse_args()
 
     # Load engine class
@@ -132,7 +122,9 @@ def main():
     print()
     if has_nodes:
         total_nps = total_nodes / total_secs if total_secs > 0 else 0.0
-        print(f"TOTAL               nodes={total_nodes:10} secs={total_secs:8.4f} nps={total_nps:10.0f}")
+        print(
+            f"TOTAL               nodes={total_nodes:10} secs={total_secs:8.4f} nps={total_nps:10.0f}"
+        )
     else:
         print(f"TOTAL               secs={total_secs:8.4f} nps=None")
 

--- a/tools/train_pattern_eval.py
+++ b/tools/train_pattern_eval.py
@@ -36,9 +36,11 @@ import time
 from concurrent.futures import ProcessPoolExecutor, as_completed
 
 REPO = os.path.normpath(os.path.join(os.path.dirname(__file__), ".."))
-CKPT = os.path.join(
-    os.environ.get("TURBO_CKPT_DIR", ""), ""
-) if os.environ.get("TURBO_CKPT_DIR") else None
+CKPT = (
+    os.path.join(os.environ.get("TURBO_CKPT_DIR", ""), "")
+    if os.environ.get("TURBO_CKPT_DIR")
+    else None
+)
 for p in (REPO,):
     if p not in sys.path:
         sys.path.insert(0, p)
@@ -57,14 +59,16 @@ if _CKPT_DIR not in sys.path:
 # Self-play data generation (worker side)
 # ---------------------------------------------------------------------------
 
+
 def _gen_games(args) -> list[tuple[int, int, int, int, float]]:
     """Play ``n`` self-play games; return sampled (wm,wk,bm,bk,result_white)."""
     seed, n, depth, max_plies, min_open, max_open, cap = args
     rng = random.Random(seed)
 
+    import turbo_v2 as v2  # frozen checkpoint engine + movegen
+
     from draughts import Board
     from draughts.models import Color
-    import turbo_v2 as v2  # frozen checkpoint engine + movegen
 
     eng = v2.TurboEngine(depth_limit=depth, time_limit=None)
     samples: list[tuple[int, int, int, int, float]] = []
@@ -118,14 +122,14 @@ def _gen_games_scan(args):
     """Short Scan self-play rollouts; label every fully-quiet position with
     Scan's own search score (white perspective).  One search per ply already
     happens to pick the move, so the eval label is essentially free."""
-    (seed, n, scan_path, move_time, roll_plies, min_open, max_open,
-     cap) = args
+    (seed, n, scan_path, move_time, roll_plies, min_open, max_open, cap) = args
     rng = random.Random(seed)
 
-    from draughts import Board
-    from draughts.models import Color
     import turbo_v2 as v2
+
+    from draughts import Board
     from draughts.engines import HubEngine
+    from draughts.models import Color
 
     samples = []
     with HubEngine(scan_path, time_limit=move_time) as eng:
@@ -143,7 +147,7 @@ def _gen_games_scan(args):
                 continue
 
             game_positions = []  # (wm,wk,bm,bk, scan_white)
-            hist = []            # positions in play order, to attach result
+            hist = []  # positions in play order, to attach result
             plies = 0
             while not board.game_over and plies < roll_plies:
                 wm, wk, bm, bk = v2.TurboEngine._convert(board)
@@ -172,15 +176,15 @@ def _gen_games_scan(args):
     return samples
 
 
-def generate_scan(n_games, workers, scan_path, move_time, roll_plies,
-                  min_open, max_open, cap, seed0):
+def generate_scan(
+    n_games, workers, scan_path, move_time, roll_plies, min_open, max_open, cap, seed0
+):
     per = max(1, n_games // workers)
     tasks = []
     remaining, s = n_games, seed0
     while remaining > 0:
         g = min(per, remaining)
-        tasks.append((s, g, scan_path, move_time, roll_plies,
-                      min_open, max_open, cap))
+        tasks.append((s, g, scan_path, move_time, roll_plies, min_open, max_open, cap))
         remaining -= g
         s += 1
     all_samples = []
@@ -191,11 +195,13 @@ def generate_scan(n_games, workers, scan_path, move_time, roll_plies,
         for f in as_completed(futs):
             all_samples.extend(f.result())
             done += 1
-            print(f"  scan worker {done}/{len(tasks)} done, "
-                  f"{len(all_samples)} samples, "
-                  f"{time.perf_counter()-t0:.0f}s", flush=True)
-    print(f"generated {len(all_samples)} scan-labelled samples in "
-          f"{time.perf_counter()-t0:.0f}s")
+            print(
+                f"  scan worker {done}/{len(tasks)} done, "
+                f"{len(all_samples)} samples, "
+                f"{time.perf_counter() - t0:.0f}s",
+                flush=True,
+            )
+    print(f"generated {len(all_samples)} scan-labelled samples in {time.perf_counter() - t0:.0f}s")
     return all_samples
 
 
@@ -220,11 +226,10 @@ def generate(n_games, workers, depth, max_plies, min_open, max_open, cap, seed0)
             done += 1
             print(
                 f"  worker {done}/{len(tasks)} done, "
-                f"{len(all_samples)} samples, {time.perf_counter()-t0:.0f}s",
+                f"{len(all_samples)} samples, {time.perf_counter() - t0:.0f}s",
                 flush=True,
             )
-    print(f"generated {len(all_samples)} raw samples in "
-          f"{time.perf_counter()-t0:.0f}s")
+    print(f"generated {len(all_samples)} raw samples in {time.perf_counter() - t0:.0f}s")
     return all_samples
 
 
@@ -232,9 +237,11 @@ def generate(n_games, workers, depth, max_plies, min_open, max_open, cap, seed0)
 # Feature extraction + 180-degree augmentation
 # ---------------------------------------------------------------------------
 
+
 def _rot_map():
     """Internal-bit remap for a 180-degree board rotation (square s -> 49-s)."""
     import turbo_v2 as v2
+
     # bit -> bit for rotated square
     remap = {}
     for s in range(50):
@@ -287,10 +294,11 @@ def build_features(samples, mode="full"):
     """
     import numpy as np
     import turbo_v2 as v2
+
     from draughts.engines.turbo import (
-        pattern_indices,
         N_PATTERNS,
         PAT_ENTRIES,
+        pattern_indices,
     )
 
     remap = _rot_map()
@@ -331,14 +339,17 @@ def build_features(samples, mode="full"):
 # Texel fit (Adam gradient descent, full batch)
 # ---------------------------------------------------------------------------
 
+
 def _sigmoid(x):
     import numpy as np
+
     return 1.0 / (1.0 + np.exp(-np.clip(x, -40.0, 40.0)))
 
 
 def fit_k(E, y, lo=0.001, hi=0.03, n=60):
     """1-D fit of K minimising MSE of sigmoid(K*E) vs y."""
     import numpy as np
+
     best_k, best_mse = lo, 1e9
     for k in np.linspace(lo, hi, n):
         mse = float(np.mean((_sigmoid(k * E) - y) ** 2))
@@ -349,6 +360,7 @@ def fit_k(E, y, lo=0.001, hi=0.03, n=60):
 
 def _metrics(E, y, K):
     import numpy as np
+
     p = _sigmoid(K * E)
     mse = float(np.mean((p - y) ** 2))
     eps = 1e-12
@@ -363,6 +375,7 @@ def fit(base, cells, y, n_weights, lam, iters, lr, k0, val_frac=0.1, seed=0):
     ill-conditioned), then refit 1-D on the trained eval at the end.
     """
     import numpy as np
+
     rng = np.random.default_rng(seed)
     N = len(y)
     P = cells.shape[1]
@@ -378,7 +391,8 @@ def fit(base, cells, y, n_weights, lam, iters, lr, k0, val_frac=0.1, seed=0):
     base_tr = base[tr].astype(np.float64)
     y_tr = y[tr].astype(np.float64)
 
-    mw = np.zeros_like(w); vw = np.zeros_like(w)
+    mw = np.zeros_like(w)
+    vw = np.zeros_like(w)
     b1, b2, eps = 0.9, 0.999, 1e-8
 
     for t in range(1, iters + 1):
@@ -391,16 +405,19 @@ def fit(base, cells, y, n_weights, lam, iters, lr, k0, val_frac=0.1, seed=0):
 
         mw = b1 * mw + (1 - b1) * gw
         vw = b2 * vw + (1 - b2) * gw * gw
-        w -= lr * (mw / (1 - b1 ** t)) / (np.sqrt(vw / (1 - b2 ** t)) + eps)
+        w -= lr * (mw / (1 - b1**t)) / (np.sqrt(vw / (1 - b2**t)) + eps)
 
         if t % 25 == 0 or t == iters:
             Et = base_tr + w[cells_tr].sum(axis=1)
             Ev = base[val] + w[cells[val]].sum(axis=1)
             tr_mse, tr_ll = _metrics(Et, y_tr, K)
             v_mse, v_ll = _metrics(Ev, y[val], K)
-            print(f"  iter {t:4d}  tr_mse={tr_mse:.5f} val_mse={v_mse:.5f}  "
-                  f"val_ll={v_ll:.5f}  |w|max={np.abs(w).max():.1f}  "
-                  f"nz={int(np.count_nonzero(np.abs(w)>0.5))}", flush=True)
+            print(
+                f"  iter {t:4d}  tr_mse={tr_mse:.5f} val_mse={v_mse:.5f}  "
+                f"val_ll={v_ll:.5f}  |w|max={np.abs(w).max():.1f}  "
+                f"nz={int(np.count_nonzero(np.abs(w) > 0.5))}",
+                flush=True,
+            )
 
     # Refit K on trained eval (train split), then report on val.
     Etr = base_tr + w[cells_tr].sum(axis=1)
@@ -411,12 +428,12 @@ def fit(base, cells, y, n_weights, lam, iters, lr, k0, val_frac=0.1, seed=0):
     return w, K, tr_mse, v_mse
 
 
-def fit_regression(base, cells, target, n_weights, lam, iters, lr,
-                   val_frac=0.1, seed=0):
+def fit_regression(base, cells, target, n_weights, lam, iters, lr, val_frac=0.1, seed=0):
     """Least-squares: teach (base + patterns) -> target eval (Scan, v2 units).
 
     Convex in w; Adam.  Returns (w, train_rmse, val_rmse, base_val_rmse)."""
     import numpy as np
+
     rng = np.random.default_rng(seed)
     N = len(target)
     P = cells.shape[1]
@@ -432,43 +449,49 @@ def fit_regression(base, cells, target, n_weights, lam, iters, lr,
     tgt_tr = target[tr].astype(np.float64)
 
     base_val_rmse = float(np.sqrt(np.mean((base[val] - target[val]) ** 2)))
-    mw = np.zeros_like(w); vw = np.zeros_like(w)
+    mw = np.zeros_like(w)
+    vw = np.zeros_like(w)
     b1, b2, eps = 0.9, 0.999, 1e-8
 
     for t in range(1, iters + 1):
         resid = base_tr + w[cells_tr].sum(axis=1) - tgt_tr
-        gw = np.bincount(flat_tr, weights=np.repeat((2.0 / Ntr) * resid, P),
-                         minlength=n_weights)
+        gw = np.bincount(flat_tr, weights=np.repeat((2.0 / Ntr) * resid, P), minlength=n_weights)
         gw += 2.0 * lam * w
         mw = b1 * mw + (1 - b1) * gw
         vw = b2 * vw + (1 - b2) * gw * gw
-        w -= lr * (mw / (1 - b1 ** t)) / (np.sqrt(vw / (1 - b2 ** t)) + eps)
+        w -= lr * (mw / (1 - b1**t)) / (np.sqrt(vw / (1 - b2**t)) + eps)
         if t % 50 == 0 or t == iters:
             rv = base[val] + w[cells[val]].sum(axis=1) - target[val]
-            print(f"  iter {t:4d}  train_rmse="
-                  f"{np.sqrt(np.mean(resid**2)):.2f}  "
-                  f"val_rmse={np.sqrt(np.mean(rv**2)):.2f}  "
-                  f"(base {base_val_rmse:.2f})  |w|max={np.abs(w).max():.1f}  "
-                  f"nz={int(np.count_nonzero(np.abs(w)>0.5))}", flush=True)
+            print(
+                f"  iter {t:4d}  train_rmse="
+                f"{np.sqrt(np.mean(resid**2)):.2f}  "
+                f"val_rmse={np.sqrt(np.mean(rv**2)):.2f}  "
+                f"(base {base_val_rmse:.2f})  |w|max={np.abs(w).max():.1f}  "
+                f"nz={int(np.count_nonzero(np.abs(w) > 0.5))}",
+                flush=True,
+            )
 
     rtr = base_tr + w[cells_tr].sum(axis=1) - tgt_tr
     rv = base[val] + w[cells[val]].sum(axis=1) - target[val]
-    return (w, float(np.sqrt(np.mean(rtr ** 2))),
-            float(np.sqrt(np.mean(rv ** 2))), base_val_rmse)
+    return (w, float(np.sqrt(np.mean(rtr**2))), float(np.sqrt(np.mean(rv**2))), base_val_rmse)
 
 
 def write_weights(path, w, n_pat, n_ent):
     import numpy as np
+
     wi = np.clip(np.round(w), -32000, 32000).astype("<i2")
     with open(path, "wb") as f:
         f.write(b"TPW1")
         f.write(struct.pack("<HH", n_pat, n_ent))
         f.write(wi.tobytes())
-    print(f"wrote {path} ({os.path.getsize(path)} bytes, "
-          f"nonzero={int(np.count_nonzero(wi))}/{len(wi)})")
+    print(
+        f"wrote {path} ({os.path.getsize(path)} bytes, "
+        f"nonzero={int(np.count_nonzero(wi))}/{len(wi)})"
+    )
 
 
 # ---------------------------------------------------------------------------
+
 
 def main():
     ap = argparse.ArgumentParser()
@@ -484,17 +507,22 @@ def main():
     ap.add_argument("--lr", type=float, default=1.0)
     ap.add_argument("--seed", type=int, default=12345)
     ap.add_argument("--mode", default="full", choices=["full", "matref"])
-    ap.add_argument("--target", default="result",
-                    choices=["result", "scan", "blend", "scanreg"],
-                    help="training label source / objective")
-    ap.add_argument("--label", default="result", choices=["result", "scan"],
-                    help="data generator: v2 self-play vs Scan self-play")
-    ap.add_argument("--scan-exe", default=os.path.join(
-        REPO, "scan_engine", "scan_31", "scan.exe"))
+    ap.add_argument(
+        "--target",
+        default="result",
+        choices=["result", "scan", "blend", "scanreg"],
+        help="training label source / objective",
+    )
+    ap.add_argument(
+        "--label",
+        default="result",
+        choices=["result", "scan"],
+        help="data generator: v2 self-play vs Scan self-play",
+    )
+    ap.add_argument("--scan-exe", default=os.path.join(REPO, "scan_engine", "scan_31", "scan.exe"))
     ap.add_argument("--move-time", type=float, default=0.05)
     ap.add_argument("--roll-plies", type=int, default=30)
-    ap.add_argument("--feat-cache", default=None,
-                    help="npz cache for computed features")
+    ap.add_argument("--feat-cache", default=None, help="npz cache for computed features")
     ap.add_argument("--samples-in", default=None, help="reuse pickled samples")
     ap.add_argument("--samples-out", default=None)
     ap.add_argument(
@@ -504,11 +532,11 @@ def main():
     args = ap.parse_args()
 
     import numpy as np
+
     if args.feat_cache and os.path.exists(args.feat_cache):
         print(f"loading feature cache {args.feat_cache}")
         d = np.load(args.feat_cache)
-        base, cells, result, scan = (
-            d["base"], d["cells"], d["result"], d["scan"])
+        base, cells, result, scan = (d["base"], d["cells"], d["result"], d["scan"])
     else:
         if args.samples_in and os.path.exists(args.samples_in):
             print(f"loading samples from {args.samples_in}")
@@ -517,8 +545,14 @@ def main():
             print(f"  {len(samples)} samples")
         elif args.label == "scan":
             samples = generate_scan(
-                args.games, args.workers, args.scan_exe, args.move_time,
-                args.roll_plies, args.min_open, args.max_open, args.cap,
+                args.games,
+                args.workers,
+                args.scan_exe,
+                args.move_time,
+                args.roll_plies,
+                args.min_open,
+                args.max_open,
+                args.cap,
                 args.seed,
             )
             if args.samples_out:
@@ -527,8 +561,14 @@ def main():
                 print(f"saved samples -> {args.samples_out}")
         else:
             samples = generate(
-                args.games, args.workers, args.depth, args.max_plies,
-                args.min_open, args.max_open, args.cap, args.seed,
+                args.games,
+                args.workers,
+                args.depth,
+                args.max_plies,
+                args.min_open,
+                args.max_open,
+                args.cap,
+                args.seed,
             )
             if args.samples_out:
                 with open(args.samples_out, "wb") as f:
@@ -537,11 +577,11 @@ def main():
         print(f"building features (mode={args.mode}, +180-deg aug) ...")
         base, cells, result, scan = build_features(samples, args.mode)
         if args.feat_cache:
-            np.savez(args.feat_cache, base=base, cells=cells,
-                     result=result, scan=scan)
+            np.savez(args.feat_cache, base=base, cells=cells, result=result, scan=scan)
     print(f"  feature matrix: N={len(result)}  P={cells.shape[1]}")
 
     from draughts.engines.turbo import N_PATTERNS, PAT_ENTRIES
+
     n_weights = N_PATTERNS * PAT_ENTRIES
 
     have_scan = np.isfinite(scan).all()
@@ -554,15 +594,25 @@ def main():
         # teach (base + patterns) toward Scan's judgment.
         a = float(np.sum(base * scan) / np.sum(scan * scan))
         target = (a * scan).astype(np.float32)
-        print(f"scan->v2 scale a={a:.2f}  "
-              f"(target eval std={target.std():.1f}cp, "
-              f"base std={base.std():.1f}cp)")
-        w, tr_rmse, val_rmse, base_rmse = fit_regression(
-            base, cells, target, n_weights, args.lam, args.iters, args.lr,
+        print(
+            f"scan->v2 scale a={a:.2f}  "
+            f"(target eval std={target.std():.1f}cp, "
+            f"base std={base.std():.1f}cp)"
         )
-        print(f"trained: train_rmse={tr_rmse:.2f}  val_rmse={val_rmse:.2f}  "
-              f"(base {base_rmse:.2f})  gap_closed="
-              f"{100*(base_rmse-val_rmse)/base_rmse:.1f}%")
+        w, tr_rmse, val_rmse, base_rmse = fit_regression(
+            base,
+            cells,
+            target,
+            n_weights,
+            args.lam,
+            args.iters,
+            args.lr,
+        )
+        print(
+            f"trained: train_rmse={tr_rmse:.2f}  val_rmse={val_rmse:.2f}  "
+            f"(base {base_rmse:.2f})  gap_closed="
+            f"{100 * (base_rmse - val_rmse) / base_rmse:.1f}%"
+        )
         write_weights(args.out, w, N_PATTERNS, PAT_ENTRIES)
         return
 
@@ -570,8 +620,10 @@ def main():
     if have_scan:
         c_scan, _ = fit_k(scan, result, lo=0.01, hi=4.0, n=120)
         y_scan = _sigmoid(c_scan * scan)
-        print(f"scan->winprob scale c={c_scan:.4f}  "
-              f"(scan white mean={scan.mean():.3f} std={scan.std():.3f})")
+        print(
+            f"scan->winprob scale c={c_scan:.4f}  "
+            f"(scan white mean={scan.mean():.3f} std={scan.std():.3f})"
+        )
     if args.target == "result":
         y = result
     elif args.target == "scan":
@@ -582,11 +634,20 @@ def main():
     k0, base_mse = fit_k(base, y)
     print(f"base-only (patterns off): best K={k0:.5f}  MSE={base_mse:.5f}")
     w, K, tr_mse, val_mse = fit(
-        base, cells, y, n_weights, args.lam, args.iters, args.lr, k0,
+        base,
+        cells,
+        y,
+        n_weights,
+        args.lam,
+        args.iters,
+        args.lr,
+        k0,
     )
-    print(f"trained: train_mse={tr_mse:.5f}  val_mse={val_mse:.5f}  "
-          f"(base val baseline ~{base_mse:.5f})  reduction="
-          f"{100*(base_mse-val_mse)/base_mse:.1f}%")
+    print(
+        f"trained: train_mse={tr_mse:.5f}  val_mse={val_mse:.5f}  "
+        f"(base val baseline ~{base_mse:.5f})  reduction="
+        f"{100 * (base_mse - val_mse) / base_mse:.1f}%"
+    )
     write_weights(args.out, w, N_PATTERNS, PAT_ENTRIES)
 
 

--- a/tools/workers/engine_worker.py
+++ b/tools/workers/engine_worker.py
@@ -20,7 +20,7 @@ import time
 
 # Import once at startup
 from draughts import StandardBoard
-from draughts.engines import AlphaBetaEngine
+from draughts.engines import SimpleEngine
 from draughts.move import Move
 
 # Persistent board state across moves in same game
@@ -76,7 +76,7 @@ def handle_move(depth: int) -> dict:
             "time_ms": 0,
         }
 
-    engine = AlphaBetaEngine(depth_limit=depth)
+    engine = SimpleEngine(depth_limit=depth)
     start = time.perf_counter()
     move = engine.get_best_move(current_board)
     elapsed_ms = (time.perf_counter() - start) * 1000

--- a/tools/workers/get_engine_move.py
+++ b/tools/workers/get_engine_move.py
@@ -11,7 +11,7 @@ def main():
     depth = int(sys.argv[2]) if len(sys.argv) > 2 else 3
 
     from draughts import StandardBoard
-    from draughts.engines import AlphaBetaEngine
+    from draughts.engines import SimpleEngine
 
     board = StandardBoard.from_fen(fen) if fen else StandardBoard()
 
@@ -25,7 +25,7 @@ def main():
             "time_ms": 0,
         }
     else:
-        engine = AlphaBetaEngine(depth_limit=depth)
+        engine = SimpleEngine(depth_limit=depth)
         start = time.perf_counter()
         move = engine.get_best_move(board)
         elapsed_ms = (time.perf_counter() - start) * 1000


### PR DESCRIPTION
Makes `TurboEngine` the primary built-in engine, replaces `AlphaBetaEngine` with a general-purpose `SimpleEngine`, and adds reusable engine-comparison tooling plus the write-up of the (negative-result) v4 eval-tuning investigation.

## Engine change (breaking)
- **`AlphaBetaEngine` → `SimpleEngine`** (`draughts/engines/alpha_beta.py` → `simple.py`). Same engine — alpha-beta + transposition tables + iterative deepening — that works on **all variants**. `draughts.AlphaBetaEngine` is removed; use `draughts.SimpleEngine` (identical API).
- **`TurboEngine` is now the flagship** across README + docs. Note: TurboEngine is international-10×10 only; `SimpleEngine` is the engine for the other 7 variants (American, Frisian, Russian, Brazilian, Antidraughts, Breakthrough, Frysk!).
- All call sites updated: `benchmark.py`, `agent.py`, `server.py`, examples, tools, tests.

## Tooling
- **`tools/profile_turbo.py`** — nodes/s profiler for any engine module.
- **`tools/elo_benchmark.py`** — head-to-head benchmark reporting **Elo with a standard error** + significance verdict (the built-in `Benchmark` gives a point estimate only). Spec strings like `--e1 turbo:time=0.1 --e2 turbo:time=0.3`.

## Docs
- `docs/turbo-v4-investigation.md` — full write-up of the v4 eval-tuning effort and why it reached parity with v3 (kept as the shipped engine). No engine/weights strength change.

## CI
Fixes pre-existing ruff `check`/`format` issues (main's CI was already red) so the pipeline goes green. `ruff check`, `ruff format --check`, `mypy`, and `pytest` (386 passing) all clean locally.

## Note
This is a **breaking API change** (public `AlphaBetaEngine` removed) — warrants a major version bump on the next release.