### PR TITLE
Reject men on the promotion row in FEN + enforce Russian king capture continuation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,32 @@
 
 ## Unreleased
 
+Bug fixes:
+
+- **FEN promotion-row validation** (#47): `Board.from_fen` now rejects a man
+  placed on its own promotion row (e.g. `W:W4:B49` in international draughts —
+  both 4 and 49 are promotion squares), since any move ending there crowns the
+  piece and only a king can legally occupy it. Kings on the promotion row and
+  men on the *opponent's* promotion row are unaffected.
+- **Russian king capture continuation**: a capturing king could stop on any
+  landing square behind its victim even when another landing square offered a
+  further capture. Per the FMJD-64 rules (art. 4.6) the king must land where it
+  can continue and capture until no continuation exists; the free choice of
+  landing square applies only behind the last captured piece. In
+  `B:W12,17,19,23,25,27,29:B1,3,4,7,8,10,11,K13,14` the early stops `13x22`,
+  `13x26` and `13x31x20` are no longer generated — `13x31x24x15` is the king's
+  only legal move, matching lidraughts/pydraughts. Other variants are
+  unaffected (the maximum-capture rule already filtered such stops).
+
 New:
+
+- **Cross-variant FEN test suite**: `test/test_fen.py` checks all eight
+  variants uniformly — promotion-row rejection, FEN round-trip fidelity from
+  random play, and parser robustness against malformed input. The full
+  position/move corpus was additionally cross-validated against the
+  independent `pydraughts` package (2,900+ random-play positions across all
+  variants with exact legal-move-set parity; American differs only by this
+  library's documented optional-captures rule).
 
 - **TurboEngine strength benchmarks + in-depth docs**: `tools/measure_turbo_elo.py`
   measures TurboEngine's strength — a self-play depth ladder, the flagship gap vs

--- a/draughts/boards/_core.py
+++ b/draughts/boards/_core.py
@@ -28,7 +28,11 @@ scattered conditionals:
 
 The maximum-capture rule (Standard/Brazilian) is applied by the board on the
 raw chains this core returns, not here, so free-choice variants (Russian /
-American) simply keep every chain.
+American) simply keep every chain. One legality rule IS enforced here because
+it is not expressible as a post-filter on chain lengths: a flying king that
+could continue capturing from some landing square behind its victim must do
+so (FMJD-64 art. 4.6), so ``king_dfs`` never emits an early-stop terminal
+while a sibling landing square allows a continuation.
 
 In every variant a captured piece stays on the board as a blocker until the
 whole chain ends: it may be neither jumped twice nor landed on nor (for flying
@@ -202,7 +206,19 @@ class MoveGen:
 
         def king_dfs(cur, enemy_rem, occ, promo, path, caps, out):
             """Flying-king capture chains. ``occ`` excludes the moving king but
-            keeps captured pieces as blockers."""
+            keeps captured pieces as blockers.
+
+            The landing square behind a victim is a free choice only when NO
+            landing square offers a further capture: if the king can continue
+            from some square behind the piece it just took, it is obliged to
+            land there and keep capturing (FMJD-64 rules art. 4.6), so the
+            would-be terminals on the sibling landing squares are discarded.
+            For the maximum-capture variants this pruning is a no-op (an early
+            stop is always shorter than the forced continuation and would be
+            dropped by the max filter anyway); it changes the generated set
+            only for free-choice Russian, where every returned chain is legal
+            as-is.
+            """
             extended = False
             for sh in all_dirs:
                 pos = sh > 0
@@ -216,13 +232,21 @@ class MoveGen:
                 new_enemy = enemy_rem ^ victim
                 caps.append(b2s[victim.bit_length() - 1])
                 land = (victim << step) if pos else (victim >> step)
+                pending = None  # terminals held back until this victim's verdict
+                continued = False
                 while land & SQ_MASK and not land & occ:
                     extended = True
                     path.append(b2s[land.bit_length() - 1])
-                    if not king_dfs(land, new_enemy, occ, promo, path, caps, out):
-                        out.append((tuple(path), tuple(caps), promo))
+                    if king_dfs(land, new_enemy, occ, promo, path, caps, out):
+                        continued = True
+                    elif not continued:
+                        if pending is None:
+                            pending = []
+                        pending.append((tuple(path), tuple(caps), promo))
                     path.pop()
                     land = (land << step) if pos else (land >> step)
+                if pending is not None and not continued:
+                    out.extend(pending)
                 caps.pop()
             return extended
 

--- a/draughts/boards/base.py
+++ b/draughts/boards/base.py
@@ -543,7 +543,9 @@ class BaseBoard(ABC):
             New board instance with the specified position.
 
         Raises:
-            ValueError: If the FEN string is invalid.
+            ValueError: If the FEN string is invalid, references a square more
+                than once, or places a man (non-king) on its own promotion row
+                (issue #47) -- such a piece could only legally exist as a king.
 
         Example:
             >>> board = Board.from_fen("W:WK10,K20:BK35,K45")
@@ -582,7 +584,10 @@ class BaseBoard(ABC):
             raise ValueError(f"Invalid FEN: {fen}")
 
         position = np.zeros(cls.SQUARES_COUNT, dtype=np.int8)
-        for group, king_val, man_val in ((r.group(2), -2, -1), (r.group(3), 2, 1)):
+        for group, king_val, man_val, promo_row in (
+            (r.group(2), -2, -1, cls.PROMO_WHITE),
+            (r.group(3), 2, 1, cls.PROMO_BLACK),
+        ):
             if not group:
                 continue
             for sq_str in group.split(","):
@@ -590,6 +595,14 @@ class BaseBoard(ABC):
                     idx = piece["square"] - 1
                     if position[idx] != 0:
                         raise ValueError(f"Duplicate square in FEN: {piece['square']}")
+                    # A man on its own promotion row is impossible: any move
+                    # ending there crowns it, so only a king can occupy the
+                    # square in a legal position (issue #47).
+                    if not piece["king"] and promo_row & (1 << idx):
+                        raise ValueError(
+                            f"Invalid FEN: man on promotion square {piece['square']} "
+                            f"(only a king may stand there)"
+                        )
                     position[idx] = king_val if piece["king"] else man_val
 
         return cls(position, Color.WHITE if r.group(1) == "W" else Color.BLACK)

--- a/draughts/boards/russian.py
+++ b/draughts/boards/russian.py
@@ -10,6 +10,10 @@ Key differences from other variants:
 - Mid-capture promotion: if a man reaches promotion rank during a capture, it
   immediately becomes a king and continues capturing as a king
 - Mandatory captures (must capture if able, but can choose which sequence)
+- A capturing king must keep capturing while it can: if any landing square
+  behind the captured piece allows a further capture, the king is obliged to
+  land on such a square and continue (FMJD-64 rules art. 4.6). Free choice of
+  the final landing square exists only behind the last captured piece.
 """
 
 from __future__ import annotations

--- a/readme.md
+++ b/readme.md
@@ -340,51 +340,85 @@ import torch
 import torch.nn as nn
 from draughts.boards.standard import Board  # 10x10 International
 
-def board_features(x):   # material + parity — what a flat MLP can't see in raw bits
-    c = x.sum(2); om, ok, pm, pk = c[:, 0], c[:, 1], c[:, 2], c[:, 3]; total = c.sum(1)
-    return torch.stack([om/15, ok/5, pm/15, pk/5, (om + 3*ok - pm - 3*pk)/15,
-                        (ok - pk)/5, total/40, total % 2, (om + ok) % 2,
-                        om % 2, pm % 2], dim=1)
 
-class ValueNet(nn.Module):                    # ~630K params
+def board_features(x):  # material + parity — what a flat MLP can't see in raw bits
+    c = x.sum(2)
+    om, ok, pm, pk = c[:, 0], c[:, 1], c[:, 2], c[:, 3]
+    total = c.sum(1)
+    return torch.stack(
+        [
+            om / 15,
+            ok / 5,
+            pm / 15,
+            pk / 5,
+            (om + 3 * ok - pm - 3 * pk) / 15,
+            (ok - pk) / 5,
+            total / 40,
+            total % 2,
+            (om + ok) % 2,
+            om % 2,
+            pm % 2,
+        ],
+        dim=1,
+    )
+
+
+class ValueNet(nn.Module):  # ~630K params
     def __init__(self, h=512):
         super().__init__()
         self.body = nn.Sequential(
-            nn.Linear(4*50 + 11, h), nn.ReLU(), nn.Dropout(0.3),
-            nn.Linear(h, h), nn.ReLU(), nn.Dropout(0.3),
-            nn.Linear(h, h), nn.ReLU(),
-            nn.Linear(h, 1), nn.Tanh(),
+            nn.Linear(4 * 50 + 11, h),
+            nn.ReLU(),
+            nn.Dropout(0.3),
+            nn.Linear(h, h),
+            nn.ReLU(),
+            nn.Dropout(0.3),
+            nn.Linear(h, h),
+            nn.ReLU(),
+            nn.Linear(h, 1),
+            nn.Tanh(),
         )
+
     def forward(self, x):
         flat = x.reshape(x.shape[0], -1)
         return self.body(torch.cat([flat, board_features(x)], dim=1)).squeeze(-1)
 
-net = ValueNet(); net.load_state_dict(torch.load("examples/value_net_standard.pt")); net.eval()
+
+net = ValueNet()
+net.load_state_dict(torch.load("examples/value_net_standard.pt"))
+net.eval()
+
 
 @torch.no_grad()
-def evaluate(board):                          # score for the side to move
+def evaluate(board):  # score for the side to move
     return float(net(torch.from_numpy(board.to_tensor()).unsqueeze(0)))
+
 
 @torch.no_grad()
 def search(board, depth, alpha=-1e9, beta=1e9):
     moves = board.legal_moves
     if not moves:
-        return -1.0                           # side to move has lost
+        return -1.0  # side to move has lost
     quiet = not moves[0].captured_list
     if depth <= 0 and quiet:
-        return evaluate(board)                # only ever score quiet leaves
+        return evaluate(board)  # only ever score quiet leaves
     depth = depth if not quiet else depth - 1  # quiescence: captures are "free"
     best = -2.0
     for m in moves:
-        child = board.copy(); child.push(m)
+        child = board.copy()
+        child.push(m)
         best = max(best, -search(child, depth, -beta, -alpha))
         alpha = max(alpha, best)
         if alpha >= beta:
             break
     return best
 
+
 def after(board, move):
-    child = board.copy(); child.push(move); return child
+    child = board.copy()
+    child.push(move)
+    return child
+
 
 board = Board()
 # 3-ply search: play the move that leaves the opponent worst off.
@@ -412,9 +446,9 @@ from draughts import Board, Server, SimpleEngine, HubEngine
 server = Server(
     board=Board(),
     white_engine=SimpleEngine(depth_limit=6),
-    black_engine=HubEngine("path/to/scan.exe", time_limit=1.0)
+    black_engine=HubEngine("path/to/scan.exe", time_limit=1.0),
 )
-server.run() # Open http://localhost:8000
+server.run()  # Open http://localhost:8000
 ```
 
 <img width="1914" height="1022" alt="image" src="https://github.com/user-attachments/assets/20fefe48-c0d8-470d-b7d8-b9fd4e9d72e0" />

--- a/test/test_fen.py
+++ b/test/test_fen.py
@@ -1,0 +1,157 @@
+"""FEN parsing/emission guarantees shared by every variant.
+
+Complements the per-variant board tests with checks that run over all eight
+variants uniformly:
+
+* men on their own promotion row are rejected (issue #47), while kings there
+  and men on the *opponent's* promotion row stay legal;
+* ``board.fen`` -> ``from_fen`` round-trips bit-exactly from randomly played
+  positions, so the emitter can never produce a FEN the parser refuses or
+  reinterprets.
+"""
+
+from __future__ import annotations
+
+import random
+
+import numpy as np
+import pytest
+
+from test._test_helpers import BOARDS
+
+VARIANTS = sorted(BOARDS)
+
+
+def _squares(mask: int) -> list[int]:
+    """1-indexed squares of a promotion-row bitmask."""
+    return [i + 1 for i in range(mask.bit_length()) if mask & (1 << i)]
+
+
+# --------------------------------------------------------------------------- #
+# Issue #47: a man on its own promotion row is an illegal FEN.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("variant", VARIANTS)
+def test_rejects_man_on_own_promotion_row(variant):
+    cls = BOARDS[variant]
+    white_promo = _squares(cls.PROMO_WHITE)
+    black_promo = _squares(cls.PROMO_BLACK)
+    last = cls.SQUARES_COUNT
+
+    for sq in white_promo:
+        with pytest.raises(ValueError, match="promotion"):
+            cls.from_fen(f"W:W{sq}:B{last}")
+    for sq in black_promo:
+        with pytest.raises(ValueError, match="promotion"):
+            cls.from_fen(f"W:WK1:B{sq}")
+
+
+@pytest.mark.parametrize("variant", VARIANTS)
+def test_rejects_range_touching_promotion_row(variant):
+    """Ranges expand square by square, so a range grazing the promotion row
+    must be rejected just like an explicit square (issue #47 + #33)."""
+    cls = BOARDS[variant]
+    first_white_promo = _squares(cls.PROMO_WHITE)[0]
+    with pytest.raises(ValueError, match="promotion"):
+        cls.from_fen(f"W:W{first_white_promo}-{first_white_promo + 1}:B{cls.SQUARES_COUNT}")
+
+
+@pytest.mark.parametrize("variant", VARIANTS)
+def test_accepts_king_on_promotion_row(variant):
+    cls = BOARDS[variant]
+    wp = _squares(cls.PROMO_WHITE)[0]
+    bp = _squares(cls.PROMO_BLACK)[0]
+    board = cls.from_fen(f"W:WK{wp}:BK{bp}")
+    assert board._get(wp - 1) == -2
+    assert board._get(bp - 1) == 2
+
+
+@pytest.mark.parametrize("variant", VARIANTS)
+def test_accepts_man_on_opponent_promotion_row(variant):
+    """A man one move away from crowning stands on the *opponent's* side of
+    the board and never on its own promotion row -- placing a white man on
+    black's promotion row (and vice versa) must stay legal."""
+    cls = BOARDS[variant]
+    white_on_black_promo = _squares(cls.PROMO_BLACK)[0]
+    black_on_white_promo = _squares(cls.PROMO_WHITE)[0]
+    board = cls.from_fen(f"W:W{white_on_black_promo}:B{black_on_white_promo}")
+    assert board._get(white_on_black_promo - 1) == -1
+    assert board._get(black_on_white_promo - 1) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Round-trip: fen -> from_fen must reproduce the position bit-for-bit for
+# every variant, from many randomly played (hence legal) positions.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("variant", VARIANTS)
+@pytest.mark.parametrize("seed", range(5))
+def test_fen_roundtrip_random_play(variant, seed):
+    cls = BOARDS[variant]
+    board = cls()
+    rng = random.Random(seed)
+
+    for _ in range(60):
+        fen = board.fen
+        clone = cls.from_fen(fen)
+        assert clone.white_men == board.white_men, fen
+        assert clone.white_kings == board.white_kings, fen
+        assert clone.black_men == board.black_men, fen
+        assert clone.black_kings == board.black_kings, fen
+        assert clone.turn == board.turn, fen
+        # And the reparsed board must emit the identical string again.
+        assert clone.fen == fen
+
+        moves = board.legal_moves
+        if not moves:
+            break
+        board.push(rng.choice(moves))
+
+
+@pytest.mark.parametrize("variant", VARIANTS)
+def test_emitted_fen_never_places_man_on_promotion_row(variant):
+    """The emitter's own output must satisfy the parser's promotion-row rule:
+    push() crowns every man that lands on the row, so a man there can only
+    appear through state corruption -- random play must never surface one."""
+    cls = BOARDS[variant]
+    board = cls()
+    rng = random.Random(1234)
+    for _ in range(120):
+        assert board.white_men & cls.PROMO_WHITE == 0
+        assert board.black_men & cls.PROMO_BLACK == 0
+        moves = board.legal_moves
+        if not moves:
+            break
+        board.push(rng.choice(moves))
+
+
+# --------------------------------------------------------------------------- #
+# Parser robustness: forms that must parse and forms that must raise.
+# --------------------------------------------------------------------------- #
+def test_wrapped_and_bare_fens_parse_identically():
+    cls = BOARDS["standard"]
+    bare = cls.from_fen("B:W31,K6:B20,K45")
+    wrapped = cls.from_fen('[FEN "B:W31,K6:B20,K45"]')
+    assert np.array_equal(bare.position, wrapped.position)
+    assert bare.turn == wrapped.turn
+
+
+def test_lowercase_fen_parses():
+    cls = BOARDS["standard"]
+    board = cls.from_fen("b:w31,k6:b20")
+    assert board.turn.value == 1  # black
+    assert board._get(30) == -1
+    assert board._get(5) == -2
+
+
+@pytest.mark.parametrize(
+    "fen",
+    [
+        "",  # empty
+        "X:W31:B20",  # bad turn token
+        "W:W31;B20",  # bad separator
+        "W31:B20",  # missing turn field
+        "W:WB:B20",  # stray piece letter inside list
+    ],
+)
+def test_malformed_fens_raise(fen):
+    with pytest.raises(ValueError):
+        BOARDS["standard"].from_fen(fen)

--- a/test/test_russian_board.py
+++ b/test/test_russian_board.py
@@ -157,6 +157,33 @@ class TestRussianCaptures:
         # Player can choose any (no max-capture filtering)
         assert len(captures) > 0
 
+    def test_king_must_land_where_capture_continues(self):
+        """A capturing king may not stop early while a landing square with a
+        continuation exists (FMJD-64 rules art. 4.6).
+
+        Black king on 13 takes the man on 17 and could land on 22, 26 or 31.
+        From 31 (and only from 31) the capture continues over 27 and then 19,
+        so landing on 22 or 26 is illegal, as is stopping on 20 after the
+        second jump while 24 still offers the third. pydraughts/lidraughts
+        agree the full chain is the only legal king move here.
+        """
+        board = Board.from_fen("B:W12,17,19,23,25,27,29:B1,3,4,7,8,10,11,K13,14")
+        king_moves = {str(m) for m in board.legal_moves if m.square_list[0] == 12}
+        assert king_moves == {"13x31x24x15"}
+        # The man's chain (14x21x30) is untouched by the king rule.
+        assert {str(m) for m in board.legal_moves} == {"13x31x24x15", "14x21x30"}
+
+    def test_king_free_landing_choice_without_continuation(self):
+        """When no landing square continues the capture, every landing square
+        behind the victim stays available (free choice, FMJD-64 art. 4.3)."""
+        position = np.zeros(32, dtype=np.int8)
+        position[russian.A1] = -2  # white king in the corner
+        position[russian.C3] = 1  # lone black man on the long diagonal
+        board = Board(position, Color.WHITE)
+        captures = [m for m in board.legal_moves if m.captured_list]
+        # Landings d4, e5, f6, g7, h8 - all five must be offered.
+        assert len(captures) == 5
+
     def test_multi_jump_must_complete(self):
         """Once a capture chain starts, must continue until no more captures."""
         position = np.zeros(32, dtype=np.int8)

--- a/test/test_standard_board.py
+++ b/test/test_standard_board.py
@@ -202,12 +202,15 @@ class TestBoard:
         "fen",
         [
             "W:WK4,WK5,55:B4",  # stray 'W' char + out-of-range 55
-            "W:W4,4:B10",  # duplicate square
-            "W:W4:B4",  # same square claimed by both sides
+            "W:W14,14:B10",  # duplicate square
+            "W:W14:B14",  # same square claimed by both sides
             "W:W55:B4",  # square 55 above the 50-square board
             "W:W0:B4",  # square 0 below the legal range
             "W:W50-31:B1",  # reversed range
             "W:W31-31:B1",  # empty/degenerate range
+            "W:W4:B49",  # white man on its promotion row (issue #47)
+            "W:W31:B46",  # black man on its promotion row (issue #47)
+            "W:W1-20:B31-50",  # range placing men on both promotion rows
         ],
     )
     def test_from_fen_rejects_illegal_positions(self, fen):

--- a/uv.lock
+++ b/uv.lock
@@ -940,7 +940,7 @@ wheels = [
 
 [[package]]
 name = "py-draughts"
-version = "1.8.3"
+version = "1.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Fixes #47.

## FEN promotion-row validation (#47)

`Board.from_fen` now rejects a man placed on its own promotion row in every variant, using the variant's `PROMO_WHITE`/`PROMO_BLACK` masks. `W:W4:B49` is rejected on both counts (4 is on white's promotion row, 49 on black's): any move ending on the promotion row crowns the piece, so only a king can legally occupy it.

Still accepted, as before:
- kings on the promotion row (`W:WK4:B20`),
- men on the *opponent's* promotion row (a man about to crown),
- ranges (checked square-by-square, so `W:W1-20:...` is caught).

Every FEN in the repo (test corpora, docs, benchmark openings, examples) was scanned first — no legitimate position violates the new rule.

## Russian king capture continuation (FMJD-64 art. 4.6)

Cross-validating ~3,000 random-play positions per variant against the independent `pydraughts` package surfaced one real move-generation bug: a capturing flying king could stop on any landing square behind its victim even when another landing square on the same ray offered a further capture. Per the official FMJD-64 rules (art. 4.6) the king is obliged to keep capturing while it can; the landing square is a free choice only behind the **last** captured piece.

In `B:W12,17,19,23,25,27,29:B1,3,4,7,8,10,11,K13,14` the early stops `13x22`, `13x26` and `13x31x20` are no longer generated — `13x31x24x15` is the king's only legal move, matching lidraughts/pydraughts.

The fix lives in `king_dfs`: would-be terminals are held back per victim and discarded when any sibling landing square continues the chain. This is provably a no-op for the maximum-capture variants (an early stop is strictly shorter than the forced continuation, so the max filter already dropped it) and for American short kings — only free-choice Russian changes.

## New tests

- `test/test_fen.py`: cross-variant FEN suite — promotion-row rejection (squares and ranges), king/opponent-row acceptance, FEN round-trip fidelity from random play, an invariant that play never puts a man on its promotion row, and malformed-input rejection.
- `test/test_russian_board.py`: regression tests for the continuation rule and for free landing choice when no continuation exists.

## External validation

`pydraughts` shares the `draughts` import name, so it was driven in an isolated venv: **21,321 positions** (random play + synthetic man-heavy / king-heavy / sparse-endgame placements) across all 8 variants, comparing exact legal-move sets normalized to (origin, destination, captured set). Results are posted in a comment below once the run completes. The earlier 2,917-position run had zero mismatches: exact parity everywhere, with American differing only by this library's documented optional-captures rule, and Russian/Brazilian compared through pydraughts' flipped square numbering.

`pytest test/`: 520 passed, 9 skipped (Scan-oracle tests auto-skip without the binary); ruff + mypy clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5SfDUEwxSRbTwkMjtQg5z)_